### PR TITLE
feat: don't borrow path for lifetime of stream

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -350,10 +350,7 @@ impl ObjectStore for AmazonS3 {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Path>,
-    ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         Ok(self
             .list_objects_v2(prefix, None)
             .await?

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -200,10 +200,7 @@ impl ObjectStore for GoogleCloudStorage {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Path>,
-    ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let converted_prefix = prefix.map(|p| format!("{}{}", p.to_raw(), DELIMITER));
         let list_request = cloud_storage::ListRequest {
             prefix: converted_prefix,

--- a/src/local.rs
+++ b/src/local.rs
@@ -160,10 +160,7 @@ impl ObjectStore for LocalFileSystem {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Path>,
-    ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let root_path = match prefix {
             Some(prefix) => self.path_to_filesystem(prefix),
             None => self.root.to_path_buf(),

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -72,10 +72,7 @@ impl ObjectStore for InMemory {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Path>,
-    ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let last_modified = Utc::now();
 
         let storage = self.storage.read().await;

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -165,10 +165,7 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         self.inner.delete(location).await
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Path>,
-    ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         sleep(self.config().wait_list_per_call).await;
 
         // need to copy to avoid moving / referencing `self`


### PR DESCRIPTION
Tweaks the ObjectStore signature so that the path passed to ObjectStore::list is not borrowed for the lifetime of the steam. This makes it annoying to call with a temporary `Path`, and isn't actually necessary for any of the implementations.