### PR TITLE
feat: consistent handling of unsafe paths

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -201,7 +201,7 @@ impl ObjectStore for AmazonS3 {
 
             rusoto_s3::PutObjectRequest {
                 bucket: bucket_name.clone(),
-                key: escape_object_key(location),
+                key: location.to_string(),
                 body: Some(byte_stream),
                 ..Default::default()
             }
@@ -227,7 +227,7 @@ impl ObjectStore for AmazonS3 {
         let key = location.to_string();
         let get_request = rusoto_s3::GetObjectRequest {
             bucket: self.bucket_name.clone(),
-            key: escape_object_key(location),
+            key: key.clone(),
             ..Default::default()
         };
         let bucket_name = self.bucket_name.clone();
@@ -269,7 +269,7 @@ impl ObjectStore for AmazonS3 {
         let key = location.to_string();
         let head_request = rusoto_s3::HeadObjectRequest {
             bucket: self.bucket_name.clone(),
-            key: escape_object_key(location),
+            key: key.clone(),
             ..Default::default()
         };
         let s = self
@@ -325,7 +325,7 @@ impl ObjectStore for AmazonS3 {
 
         let request_factory = move || rusoto_s3::DeleteObjectRequest {
             bucket: bucket_name.clone(),
-            key: escape_object_key(location),
+            key: location.to_string(),
             ..Default::default()
         };
 
@@ -413,12 +413,6 @@ fn convert_object_meta(object: rusoto_s3::Object, bucket: &str) -> Result<Object
         last_modified,
         size,
     })
-}
-
-/// Rusoto does not escape the path used to construct object requests
-fn escape_object_key(key: &Path) -> String {
-    // Path is already URL-safe, just need to escape the % characters
-    key.as_ref().replace('%', "%25")
 }
 
 /// Configure a connection to Amazon S3 using the specified credentials in

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,8 +1,5 @@
 //! An object store implementation for S3
-use crate::{
-    path::{Path, DELIMITER},
-    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
-};
+use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result, DELIMITER};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -194,18 +191,17 @@ impl fmt::Display for AmazonS3 {
 impl ObjectStore for AmazonS3 {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         let bucket_name = self.bucket_name.clone();
-        let key = location.to_raw();
         let request_factory = move || {
             let bytes = bytes.clone();
 
             let length = bytes.len();
-            let stream_data = std::io::Result::Ok(bytes);
+            let stream_data = Ok(bytes);
             let stream = futures::stream::once(async move { stream_data });
             let byte_stream = ByteStream::new_with_size(stream, length);
 
             rusoto_s3::PutObjectRequest {
                 bucket: bucket_name.clone(),
-                key: key.to_string(),
+                key: escape_object_key(location),
                 body: Some(byte_stream),
                 ..Default::default()
             }
@@ -221,17 +217,17 @@ impl ObjectStore for AmazonS3 {
         .await
         .context(UnableToPutDataSnafu {
             bucket: &self.bucket_name,
-            path: location.to_raw(),
+            path: location.as_ref(),
         })?;
 
         Ok(())
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let key = location.to_raw().to_string();
+        let key = location.to_string();
         let get_request = rusoto_s3::GetObjectRequest {
             bucket: self.bucket_name.clone(),
-            key: key.clone(),
+            key: escape_object_key(location),
             ..Default::default()
         };
         let bucket_name = self.bucket_name.clone();
@@ -270,10 +266,10 @@ impl ObjectStore for AmazonS3 {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let key = location.to_raw().to_string();
+        let key = location.to_string();
         let head_request = rusoto_s3::HeadObjectRequest {
             bucket: self.bucket_name.clone(),
-            key: key.clone(),
+            key: escape_object_key(location),
             ..Default::default()
         };
         let s = self
@@ -325,12 +321,11 @@ impl ObjectStore for AmazonS3 {
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        let key = location.to_raw();
         let bucket_name = self.bucket_name.clone();
 
         let request_factory = move || rusoto_s3::DeleteObjectRequest {
             bucket: bucket_name.clone(),
-            key: key.to_string(),
+            key: escape_object_key(location),
             ..Default::default()
         };
 
@@ -344,7 +339,7 @@ impl ObjectStore for AmazonS3 {
         .await
         .context(UnableToDeleteDataSnafu {
             bucket: &self.bucket_name,
-            path: location.to_raw(),
+            path: location.as_ref(),
         })?;
 
         Ok(())
@@ -386,17 +381,13 @@ impl ObjectStore for AmazonS3 {
 
                     res.objects.append(&mut objects);
 
-                    res.common_prefixes.extend(
-                        list_objects_v2_result
-                            .common_prefixes
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|p| {
-                                Path::from_raw(
-                                    p.prefix.expect("can't have a prefix without a value"),
-                                )
-                            }),
-                    );
+                    let prefixes = list_objects_v2_result.common_prefixes.unwrap_or_default();
+                    res.common_prefixes.reserve(prefixes.len());
+
+                    for p in prefixes {
+                        let prefix = p.prefix.expect("can't have a prefix without a value");
+                        res.common_prefixes.push(Path::parse(prefix)?);
+                    }
 
                     Ok(res)
                 },
@@ -406,7 +397,8 @@ impl ObjectStore for AmazonS3 {
 }
 
 fn convert_object_meta(object: rusoto_s3::Object, bucket: &str) -> Result<ObjectMeta> {
-    let location = Path::from_raw(object.key.expect("object doesn't exist without a key"));
+    let key = object.key.expect("object doesn't exist without a key");
+    let location = Path::parse(key)?;
     let last_modified = match object.last_modified {
         Some(lm) => DateTime::parse_from_rfc3339(&lm)
             .context(UnableToParseLastModifiedSnafu { bucket })?
@@ -421,6 +413,12 @@ fn convert_object_meta(object: rusoto_s3::Object, bucket: &str) -> Result<Object
         last_modified,
         size,
     })
+}
+
+/// Rusoto does not escape the path used to construct object requests
+fn escape_object_key(key: &Path) -> String {
+    // Path is already URL-safe, just need to escape the % characters
+    key.as_ref().replace('%', "%25")
 }
 
 /// Configure a connection to Amazon S3 using the specified credentials in
@@ -556,7 +554,7 @@ impl AmazonS3 {
         }
         use ListState::*;
 
-        let raw_prefix = prefix.map(|p| format!("{}{}", p.to_raw(), DELIMITER));
+        let raw_prefix = prefix.map(|p| format!("{}{}", p, DELIMITER));
         let bucket = self.bucket_name.clone();
 
         let request_factory = move || rusoto_s3::ListObjectsV2Request {

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,5 +1,8 @@
 //! An object store implementation for S3
-use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result, DELIMITER};
+use crate::{
+    path::{Path, DELIMITER},
+    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -1,6 +1,8 @@
 //! An object store implementation for Azure blob storage
-use crate::path::ParseError;
-use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result, DELIMITER};
+use crate::{
+    path::{Path, DELIMITER},
+    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
+};
 use async_trait::async_trait;
 use azure_core::{prelude::*, HttpClient};
 use azure_storage::core::prelude::*;
@@ -204,7 +206,7 @@ impl ObjectStore for MicrosoftAzure {
         let common_prefixes = prefixes
             .iter()
             .map(|p| Path::parse(&p.name))
-            .collect::<Result<_, ParseError>>()?;
+            .collect::<Result<_, _>>()?;
 
         let objects = resp
             .blobs

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,8 +1,6 @@
 //! An object store implementation for Google Cloud Storage
-use crate::{
-    path::{Path, DELIMITER},
-    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
-};
+use crate::path::ParseError;
+use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result, DELIMITER};
 use async_trait::async_trait;
 use bytes::Bytes;
 use cloud_storage::{Client, Object};
@@ -114,7 +112,6 @@ impl std::fmt::Display for GoogleCloudStorage {
 #[async_trait]
 impl ObjectStore for GoogleCloudStorage {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        let location = location.to_raw();
         let bucket_name = self.bucket_name.clone();
 
         self.client
@@ -122,26 +119,25 @@ impl ObjectStore for GoogleCloudStorage {
             .create(
                 &bucket_name,
                 bytes.to_vec(),
-                location,
+                location.as_ref(),
                 "application/octet-stream",
             )
             .await
             .context(UnableToPutDataSnafu {
                 bucket: &self.bucket_name,
-                path: location,
+                path: location.to_string(),
             })?;
 
         Ok(())
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let location = location.to_raw();
         let bucket_name = self.bucket_name.clone();
 
         let bytes = self
             .client
             .object()
-            .download(&bucket_name, location)
+            .download(&bucket_name, location.as_ref())
             .await
             .map_err(|e| match e {
                 cloud_storage::Error::Other(ref text) if text.starts_with("No such object") => {
@@ -165,7 +161,7 @@ impl ObjectStore for GoogleCloudStorage {
         let object = self
             .client
             .object()
-            .read(&self.bucket_name, location.to_raw())
+            .read(&self.bucket_name, location.as_ref())
             .await
             .map_err(|e| match e {
                 cloud_storage::Error::Google(ref error) if error.error.code == 404 => {
@@ -181,27 +177,26 @@ impl ObjectStore for GoogleCloudStorage {
                 },
             })?;
 
-        Ok(convert_object_meta(&object))
+        convert_object_meta(&object)
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        let location = location.to_raw();
         let bucket_name = self.bucket_name.clone();
 
         self.client
             .object()
-            .delete(&bucket_name, location)
+            .delete(&bucket_name, location.as_ref())
             .await
             .context(UnableToDeleteDataSnafu {
                 bucket: &self.bucket_name,
-                path: location,
+                path: location.to_string(),
             })?;
 
         Ok(())
     }
 
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
-        let converted_prefix = prefix.map(|p| format!("{}{}", p.to_raw(), DELIMITER));
+        let converted_prefix = prefix.map(|p| format!("{}{}", p, DELIMITER));
         let list_request = cloud_storage::ListRequest {
             prefix: converted_prefix,
             ..Default::default()
@@ -218,7 +213,7 @@ impl ObjectStore for GoogleCloudStorage {
         let bucket_name = self.bucket_name.clone();
         let objects = object_lists
             .map_ok(move |list| {
-                futures::stream::iter(list.items.into_iter().map(|o| Ok(convert_object_meta(&o))))
+                futures::stream::iter(list.items.into_iter().map(|o| convert_object_meta(&o)))
             })
             .map_err(move |source| {
                 crate::Error::from(Error::UnableToStreamListData {
@@ -259,13 +254,21 @@ impl ObjectStore for GoogleCloudStorage {
                     bucket: &self.bucket_name,
                 })?;
 
+                let objects = list_response
+                    .items
+                    .iter()
+                    .map(convert_object_meta)
+                    .collect::<Result<_>>()?;
+
+                let common_prefixes = list_response
+                    .prefixes
+                    .iter()
+                    .map(Path::parse)
+                    .collect::<Result<_, ParseError>>()?;
+
                 ListResult {
-                    objects: list_response
-                        .items
-                        .iter()
-                        .map(convert_object_meta)
-                        .collect(),
-                    common_prefixes: list_response.prefixes.iter().map(Path::from_raw).collect(),
+                    objects,
+                    common_prefixes,
                     next_token: list_response.next_page_token,
                 }
             }
@@ -275,16 +278,16 @@ impl ObjectStore for GoogleCloudStorage {
     }
 }
 
-fn convert_object_meta(object: &Object) -> ObjectMeta {
-    let location = Path::from_raw(&object.name);
+fn convert_object_meta(object: &Object) -> Result<ObjectMeta> {
+    let location = Path::parse(&object.name)?;
     let last_modified = object.updated;
     let size = usize::try_from(object.size).expect("unsupported size on this platform");
 
-    ObjectMeta {
+    Ok(ObjectMeta {
         location,
         last_modified,
         size,
-    }
+    })
 }
 
 /// Configure a connection to Google Cloud Storage.

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,6 +1,8 @@
 //! An object store implementation for Google Cloud Storage
-use crate::path::ParseError;
-use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result, DELIMITER};
+use crate::{
+    path::{Path, DELIMITER},
+    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use cloud_storage::{Client, Object};
@@ -264,7 +266,7 @@ impl ObjectStore for GoogleCloudStorage {
                     .prefixes
                     .iter()
                     .map(Path::parse)
-                    .collect::<Result<_, ParseError>>()?;
+                    .collect::<Result<_, _>>()?;
 
                 ListResult {
                     objects,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,17 +30,16 @@ pub mod azure;
 pub mod gcp;
 pub mod local;
 pub mod memory;
-mod path;
+pub mod path;
 pub mod throttle;
 
+use crate::path::Path;
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use snafu::Snafu;
 use std::fmt::{Debug, Formatter};
-
-pub use path::*;
 
 /// An alias for a dynamically dispatched object store implementation.
 pub type DynObjectStore = dyn ObjectStore;
@@ -172,7 +171,7 @@ pub enum Error {
         display("Encountered object with invalid path: {}", source),
         context(false)
     )]
-    InvalidPath { source: ParseError },
+    InvalidPath { source: path::Error },
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,16 +176,13 @@ pub enum Error {
 }
 
 #[cfg(test)]
-mod tests {
+mod test_util {
     use super::*;
 
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-    type Result<T, E = Error> = std::result::Result<T, E>;
-
-    async fn flatten_list_stream(
+    pub async fn flatten_list_stream(
         storage: &DynObjectStore,
         prefix: Option<&Path>,
-    ) -> super::Result<Vec<Path>> {
+    ) -> Result<Vec<Path>> {
         storage
             .list(prefix)
             .await?
@@ -193,6 +190,15 @@ mod tests {
             .try_collect::<Vec<Path>>()
             .await
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::flatten_list_stream;
+
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Result<T, E = Error> = std::result::Result<T, E>;
 
     pub(crate) async fn put_get_delete_list(storage: &DynObjectStore) -> Result<()> {
         delete_fixtures(storage).await;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,5 @@
 //! An in-memory object store implementation
-use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result};
+use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,5 @@
 //! An in-memory object store implementation
-use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
+use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
@@ -186,7 +186,7 @@ mod tests {
     async fn unknown_length() {
         let integration = InMemory::new();
 
-        let location = Path::from_raw("some_file");
+        let location = Path::from("some_file");
 
         let data = Bytes::from("arbitrary data");
         let expected_data = data.clone();
@@ -209,7 +209,7 @@ mod tests {
     async fn nonexistent_location() {
         let integration = InMemory::new();
 
-        let location = Path::from_raw(NON_EXISTENT_NAME);
+        let location = Path::from(NON_EXISTENT_NAME);
 
         let err = get_nonexistent_object(&integration, Some(location))
             .await

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -1,17 +1,99 @@
 //! Path abstraction for Object Storage
 
 use itertools::Itertools;
+use snafu::{ensure, ResultExt, Snafu};
 use std::fmt::Formatter;
 
 /// The delimiter to separate object namespaces, creating a directory structure.
 pub const DELIMITER: &str = "/";
 
+/// The path delimiter as a single byte
+pub const DELIMITER_BYTE: u8 = DELIMITER.as_bytes()[0];
+
 mod parts;
 
 pub use parts::PathPart;
 
-/// An object storage location suitable for passing to cloud storage APIs such
-/// as AWS, GCS, and Azure.
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)]
+pub enum ParseError {
+    #[snafu(display("Path \"{}\" contained empty path segment", path))]
+    EmptySegment { path: String },
+
+    #[snafu(display("Error parsing Path \"{}\": \"{}\"", path, source))]
+    BadSegment {
+        path: String,
+        source: parts::InvalidPart,
+    },
+}
+
+/// A parsed path representation that can be safely written to object storage
+///
+/// # Path Safety
+///
+/// In theory object stores support any UTF-8 character sequence, however, certain character
+/// sequences cause compatibility problems with some applications and protocols. As such the
+/// naming guidelines for [S3], [GCS] and [Azure Blob Storage] all recommend sticking to a
+/// limited character subset.
+///
+/// [S3]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+/// [GCS]: https://cloud.google.com/storage/docs/naming-objects
+/// [Azure Blob Storage]: https://docs.microsoft.com/en-us/rest/api/storageservices/Naming-and-Referencing-Containers--Blobs--and-Metadata#blob-names
+///
+/// This presents libraries with two options for consistent path handling:
+///
+/// 1. Allow constructing unsafe paths, allowing for both reading and writing of data to paths
+/// that may not be consistently understood or supported
+/// 2. Disallow constructing unsafe paths, ensuring data written can be consistently handled by
+/// all other systems, but preventing interaction with objects at unsafe paths
+///
+/// This library takes the second approach, in particular:
+///
+/// * Paths are delimited by `/`
+/// * Paths do not start with a `/`
+/// * Empty path segments are discarded
+/// * Relative path segments, i.e. `.` and `..` are percent encoded
+/// * Unsafe characters are percent encoded, as described by [RFC 1738]
+///
+/// In order to provide these guarantees there are two ways to safely construct a [`Path`]
+///
+/// # Encode
+///
+/// A string containing potentially illegal path segments can be encoded to a [`Path`]
+/// using [`Path::from`] or [`Path::from_iter`].
+///
+/// ```
+/// # use object_store::Path;
+/// assert_eq!(Path::from("foo/bar").as_ref(), "foo/bar");
+/// assert_eq!(Path::from("foo//bar").as_ref(), "foo/bar");
+/// assert_eq!(Path::from("foo/../bar").as_ref(), "foo/%2E%2E/bar");
+/// assert_eq!(Path::from_iter(["foo", "foo/bar"]).as_ref(), "foo/foo%2Fbar");
+/// ```
+///
+/// Note: if provided with an already percent encoded string, this will encode it again
+///
+/// ```
+/// # use object_store::Path;
+/// assert_eq!(Path::from("foo/foo%2Fbar").as_ref(), "foo/foo%252Fbar");
+/// ```
+///
+/// # Parse
+///
+/// Alternatively a [`Path`] can be created from an existing string, returning an
+/// error if it is invalid. Unlike the encoding methods, this will permit
+/// valid percent encoded sequences.
+///
+/// ```
+/// # use object_store::Path;
+///
+/// assert_eq!(Path::parse("/foo/foo%2Fbar").unwrap().as_ref(), "foo/foo%2Fbar");
+/// Path::parse("..").unwrap_err();
+/// Path::parse("/foo//").unwrap_err();
+/// Path::parse("😀").unwrap_err();
+/// Path::parse("%Q").unwrap_err();
+/// ```
+///
+/// [RFC 1738]: https://www.ietf.org/rfc/rfc1738.txt
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Path {
     /// The raw path with no leading or trailing delimiters
@@ -19,15 +101,23 @@ pub struct Path {
 }
 
 impl Path {
-    /// Create a new [`Path`] from a string
-    pub fn from_raw(path: impl AsRef<str>) -> Self {
+    /// Parse a string as a [`Path`], returning a [`ParseError`] if invalid
+    ///
+    /// Note: this will strip any leading `/` or trailing `/`
+    pub fn parse(path: impl AsRef<str>) -> Result<Self, ParseError> {
         let path = path.as_ref();
-        Self::from_iter(path.split(DELIMITER))
-    }
 
-    /// Returns the raw encoded path in object storage
-    pub fn to_raw(&self) -> &str {
-        &self.raw
+        let stripped = path.strip_prefix(DELIMITER).unwrap_or(path);
+        let stripped = stripped.strip_suffix(DELIMITER).unwrap_or(stripped);
+
+        for segment in stripped.split(DELIMITER) {
+            ensure!(!segment.is_empty(), EmptySegmentSnafu { path });
+            PathPart::parse(segment).context(BadSegmentSnafu { path })?;
+        }
+
+        Ok(Self {
+            raw: stripped.to_string(),
+        })
     }
 
     /// Returns the [`PathPart`] of this [`Path`]
@@ -79,6 +169,30 @@ impl Path {
     }
 }
 
+impl AsRef<str> for Path {
+    fn as_ref(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl From<&str> for Path {
+    fn from(path: &str) -> Self {
+        Self::from_iter(path.split(DELIMITER))
+    }
+}
+
+impl From<String> for Path {
+    fn from(path: String) -> Self {
+        Self::from_iter(path.split(DELIMITER))
+    }
+}
+
+impl From<Path> for String {
+    fn from(path: Path) -> Self {
+        path.raw
+    }
+}
+
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.raw.fmt(f)
@@ -110,44 +224,41 @@ mod tests {
         // `foo_test.json`. A search for the prefix `foo/` should return
         // `foo/bar.json` but not `foo_test.json'.
         let prefix = Path::from_iter(["test"]);
-
-        let converted = prefix.to_raw();
-        assert_eq!(converted, "test");
+        assert_eq!(prefix.as_ref(), "test");
     }
 
     #[test]
     fn push_encodes() {
         let location = Path::from_iter(["foo/bar", "baz%2Ftest"]);
-        let converted = location.to_raw();
-        assert_eq!(converted, "foo%2Fbar/baz%252Ftest");
+        assert_eq!(location.as_ref(), "foo%2Fbar/baz%252Ftest");
     }
 
     #[test]
     fn convert_raw_before_partial_eq() {
         // dir and file_name
-        let cloud = Path::from_raw("test_dir/test_file.json");
+        let cloud = Path::from("test_dir/test_file.json");
         let built = Path::from_iter(["test_dir", "test_file.json"]);
 
         assert_eq!(built, cloud);
 
         // dir and file_name w/o dot
-        let cloud = Path::from_raw("test_dir/test_file");
+        let cloud = Path::from("test_dir/test_file");
         let built = Path::from_iter(["test_dir", "test_file"]);
 
         assert_eq!(built, cloud);
 
         // dir, no file
-        let cloud = Path::from_raw("test_dir/");
+        let cloud = Path::from("test_dir/");
         let built = Path::from_iter(["test_dir"]);
         assert_eq!(built, cloud);
 
         // file_name, no dir
-        let cloud = Path::from_raw("test_file.json");
+        let cloud = Path::from("test_file.json");
         let built = Path::from_iter(["test_file.json"]);
         assert_eq!(built, cloud);
 
         // empty
-        let cloud = Path::from_raw("");
+        let cloud = Path::from("");
         let built = Path::from_iter(["", ""]);
 
         assert_eq!(built, cloud);
@@ -155,10 +266,10 @@ mod tests {
 
     #[test]
     fn parts_after_prefix_behavior() {
-        let existing_path = Path::from_raw("apple/bear/cow/dog/egg.json");
+        let existing_path = Path::from("apple/bear/cow/dog/egg.json");
 
         // Prefix with one directory
-        let prefix = Path::from_raw("apple");
+        let prefix = Path::from("apple");
         let expected_parts: Vec<PathPart<'_>> = vec!["bear", "cow", "dog", "egg.json"]
             .into_iter()
             .map(Into::into)
@@ -167,7 +278,7 @@ mod tests {
         assert_eq!(parts, expected_parts);
 
         // Prefix with two directories
-        let prefix = Path::from_raw("apple/bear");
+        let prefix = Path::from("apple/bear");
         let expected_parts: Vec<PathPart<'_>> = vec!["cow", "dog", "egg.json"]
             .into_iter()
             .map(Into::into)
@@ -176,15 +287,15 @@ mod tests {
         assert_eq!(parts, expected_parts);
 
         // Not a prefix
-        let prefix = Path::from_raw("cow");
+        let prefix = Path::from("cow");
         assert!(existing_path.prefix_match(&prefix).is_none());
 
         // Prefix with a partial directory
-        let prefix = Path::from_raw("ap");
+        let prefix = Path::from("ap");
         assert!(existing_path.prefix_match(&prefix).is_none());
 
         // Prefix matches but there aren't any parts after it
-        let existing_path = Path::from_raw("apple/bear/cow/dog");
+        let existing_path = Path::from("apple/bear/cow/dog");
 
         let prefix = existing_path.clone();
         assert_eq!(existing_path.prefix_match(&prefix).unwrap().count(), 0);

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -62,7 +62,7 @@ pub enum Error {
 /// using [`Path::from`] or [`Path::from_iter`].
 ///
 /// ```
-/// # use object_store::Path;
+/// # use object_store::path::Path;
 /// assert_eq!(Path::from("foo/bar").as_ref(), "foo/bar");
 /// assert_eq!(Path::from("foo//bar").as_ref(), "foo/bar");
 /// assert_eq!(Path::from("foo/../bar").as_ref(), "foo/%2E%2E/bar");
@@ -72,7 +72,7 @@ pub enum Error {
 /// Note: if provided with an already percent encoded string, this will encode it again
 ///
 /// ```
-/// # use object_store::Path;
+/// # use object_store::path::Path;
 /// assert_eq!(Path::from("foo/foo%2Fbar").as_ref(), "foo/foo%252Fbar");
 /// ```
 ///
@@ -83,7 +83,7 @@ pub enum Error {
 /// valid percent encoded sequences.
 ///
 /// ```
-/// # use object_store::Path;
+/// # use object_store::path::Path;
 ///
 /// assert_eq!(Path::parse("/foo/foo%2Fbar").unwrap().as_ref(), "foo/foo%2Fbar");
 /// Path::parse("..").unwrap_err();

--- a/src/path/parts.rs
+++ b/src/path/parts.rs
@@ -1,14 +1,16 @@
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
 use std::borrow::Cow;
 
-use crate::DELIMITER_BYTE;
+use crate::path::DELIMITER_BYTE;
 use snafu::Snafu;
 
+/// Error returned by [`PathPart::parse`]
 #[derive(Debug, Snafu)]
-#[snafu(display("Invalid path segment: {}", segment))]
+#[snafu(display("Invalid path segment - got \"{}\" expected: \"{}\"", actual, expected))]
 #[allow(missing_copy_implementations)]
 pub struct InvalidPart {
-    pub segment: String,
+    actual: String,
+    expected: String,
 }
 
 /// The PathPart type exists to validate the directory/file names that form part
@@ -28,7 +30,8 @@ impl<'a> PathPart<'a> {
         let part = PathPart::from(decoded.as_ref());
         if segment != part.as_ref() {
             return Err(InvalidPart {
-                segment: segment.to_string(),
+                actual: segment.to_string(),
+                expected: part.raw.to_string(),
             });
         }
 

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -359,7 +359,7 @@ mod tests {
     }
 
     async fn place_test_object(store: &ThrottledStore<InMemory>, n_bytes: Option<usize>) -> Path {
-        let path = Path::from_raw("foo");
+        let path = Path::from("foo");
 
         if let Some(n_bytes) = n_bytes {
             let data: Vec<_> = std::iter::repeat(1u8).take(n_bytes).collect();
@@ -374,7 +374,7 @@ mod tests {
     }
 
     async fn place_test_objects(store: &ThrottledStore<InMemory>, n_entries: usize) -> Path {
-        let prefix = Path::from_raw("foo");
+        let prefix = Path::from("foo");
 
         // clean up store
         let entries: Vec<_> = store
@@ -464,7 +464,7 @@ mod tests {
         let bytes = Bytes::from(data);
 
         let t0 = Instant::now();
-        store.put(&Path::from_raw("foo"), bytes).await.unwrap();
+        store.put(&Path::from("foo"), bytes).await.unwrap();
 
         t0.elapsed()
     }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{GetResult, ListResult, ObjectMeta, ObjectStore, Path, Result};
+use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};


### PR DESCRIPTION
This rejigs the path handling to make explicit what was implicit before, **this crate only supports objects with URL-safe names**.

It then adds tests for round-tripping escaped paths, and fixes the inevitable bugs.