### PR TITLE
fix: handling of empty path prefixes

### DIFF
--- a/src/azure.rs
+++ b/src/azure.rs
@@ -1,6 +1,6 @@
 //! An object store implementation for Azure blob storage
 use crate::{
-    path::{Path, DELIMITER},
+    path::{format_prefix, Path, DELIMITER},
     GetResult, ListResult, ObjectMeta, ObjectStore, Result,
 };
 use async_trait::async_trait;
@@ -154,7 +154,8 @@ impl ObjectStore for MicrosoftAzure {
             Done,
         }
 
-        let prefix_raw = prefix.map(|p| format!("{}{}", p.to_raw(), DELIMITER));
+        let prefix_raw = format_prefix(prefix);
+
         Ok(stream::unfold(ListState::Start, move |state| {
             let mut request = self.container_client.list_blobs();
 
@@ -192,13 +193,13 @@ impl ObjectStore for MicrosoftAzure {
         .boxed())
     }
 
-    async fn list_with_delimiter(&self, prefix: &Path) -> Result<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
         let mut request = self.container_client.list_blobs();
 
-        let prefix_raw = format!("{}{}", prefix, DELIMITER);
-
         request = request.delimiter(Delimiter::new(DELIMITER));
-        request = request.prefix(&*prefix_raw);
+        if let Some(prefix) = format_prefix(prefix) {
+            request = request.prefix(prefix)
+        }
 
         let resp = request.execute().await.context(ListSnafu)?;
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,6 +1,6 @@
 //! An object store implementation for Google Cloud Storage
 use crate::{
-    path::{Path, DELIMITER},
+    path::{format_prefix, Path, DELIMITER},
     GetResult, ListResult, ObjectMeta, ObjectStore, Result,
 };
 use async_trait::async_trait;
@@ -201,9 +201,8 @@ impl ObjectStore for GoogleCloudStorage {
     }
 
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
-        let converted_prefix = prefix.map(|p| format!("{}{}", p.to_raw(), DELIMITER));
         let list_request = cloud_storage::ListRequest {
-            prefix: converted_prefix,
+            prefix: format_prefix(prefix),
             ..Default::default()
         };
         let object_lists = self
@@ -230,10 +229,9 @@ impl ObjectStore for GoogleCloudStorage {
         Ok(objects.try_flatten().boxed())
     }
 
-    async fn list_with_delimiter(&self, prefix: &Path) -> Result<ListResult> {
-        let converted_prefix = format!("{}{}", prefix, DELIMITER);
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
         let list_request = cloud_storage::ListRequest {
-            prefix: Some(converted_prefix),
+            prefix: format_prefix(prefix),
             delimiter: Some(DELIMITER.to_string()),
             ..Default::default()
         };

--- a/src/local.rs
+++ b/src/local.rs
@@ -187,9 +187,11 @@ impl ObjectStore for LocalFileSystem {
         Ok(stream::iter(s).boxed())
     }
 
-    async fn list_with_delimiter(&self, prefix: &Path) -> Result<ListResult> {
-        let resolved_prefix = self.path_to_filesystem(prefix);
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        let root = Path::default();
+        let prefix = prefix.unwrap_or(&root);
 
+        let resolved_prefix = self.path_to_filesystem(prefix);
         let walkdir = WalkDir::new(&resolved_prefix).min_depth(1).max_depth(1);
 
         let mut common_prefixes = BTreeSet::new();
@@ -418,7 +420,7 @@ mod tests {
         }
 
         // `list_with_delimiter
-        assert!(store.list_with_delimiter(&Path::default()).await.is_err());
+        assert!(store.list_with_delimiter(None).await.is_err());
     }
 
     const NON_EXISTENT_NAME: &str = "nonexistentname";

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -94,7 +94,10 @@ impl ObjectStore for InMemory {
     /// The memory implementation returns all results, as opposed to the cloud
     /// versions which limit their results to 1k or more because of API
     /// limitations.
-    async fn list_with_delimiter(&self, prefix: &Path) -> Result<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        let root = Path::default();
+        let prefix = prefix.unwrap_or(&root);
+
         let mut common_prefixes = BTreeSet::new();
         let last_modified = Utc::now();
 

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -47,8 +47,8 @@ impl Path {
         prefix: &Self,
     ) -> Option<impl Iterator<Item = PathPart<'_>> + '_> {
         let diff = itertools::diff_with(
-            self.raw.split(DELIMITER),
-            prefix.raw.split(DELIMITER),
+            self.raw.split(DELIMITER).filter(|x| !x.is_empty()),
+            prefix.raw.split(DELIMITER).filter(|x| !x.is_empty()),
             |a, b| a == b,
         );
 
@@ -98,6 +98,14 @@ where
 
         Self { raw }
     }
+}
+
+/// Returns the prefix to be passed to an object store
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+pub(crate) fn format_prefix(prefix: Option<&Path>) -> Option<String> {
+    prefix
+        .filter(|x| !x.to_raw().is_empty())
+        .map(|p| format!("{}{}", p.to_raw(), DELIMITER))
 }
 
 #[cfg(test)]
@@ -243,6 +251,15 @@ mod tests {
         assert!(
             !haystack.prefix_matches(&needle),
             "{:?} should not have started with {:?}",
+            haystack,
+            needle
+        );
+
+        // empty prefix matches
+        let needle = Path::from_raw("");
+        assert!(
+            haystack.prefix_matches(&needle),
+            "{:?} should have started with {:?}",
             haystack,
             needle
         );

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -193,7 +193,7 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         })
     }
 
-    async fn list_with_delimiter(&self, prefix: &Path) -> Result<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
         sleep(self.config().wait_list_with_delimiter_per_call).await;
 
         match self.inner.list_with_delimiter(prefix).await {
@@ -454,7 +454,7 @@ mod tests {
         let prefix = place_test_objects(store, n_entries).await;
 
         let t0 = Instant::now();
-        store.list_with_delimiter(&prefix).await.unwrap();
+        store.list_with_delimiter(Some(&prefix)).await.unwrap();
 
         t0.elapsed()
     }


### PR DESCRIPTION
This fixes handling of empty path prefixes, and also makes list_with_delimiter take an `Option<&Path>` to be consistent with the standard list signature