### PR TITLE
feat: add support for range requests

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,6 +1,9 @@
 //! An object store implementation for S3
+use crate::util::format_range;
 use crate::{
-    path::{format_prefix, Path, DELIMITER},
+    collect_bytes,
+    path::{Path, DELIMITER},
+    util::format_prefix,
     GetResult, ListResult, ObjectMeta, ObjectStore, Result,
 };
 use async_trait::async_trait;
@@ -8,13 +11,14 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{
     stream::{self, BoxStream},
-    Future, StreamExt, TryStreamExt,
+    Future, Stream, StreamExt, TryStreamExt,
 };
 use hyper::client::Builder as HyperBuilder;
 use rusoto_core::ByteStream;
 use rusoto_credential::{InstanceMetadataProvider, StaticProvider};
 use rusoto_s3::S3;
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::ops::Range;
 use std::{convert::TryFrom, fmt, num::NonZeroUsize, ops::Deref, sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, warn};
@@ -227,45 +231,15 @@ impl ObjectStore for AmazonS3 {
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let key = location.to_string();
-        let get_request = rusoto_s3::GetObjectRequest {
-            bucket: self.bucket_name.clone(),
-            key: key.clone(),
-            ..Default::default()
-        };
-        let bucket_name = self.bucket_name.clone();
-        let s = self
-            .client()
-            .await
-            .get_object(get_request)
-            .await
-            .map_err(|e| match e {
-                rusoto_core::RusotoError::Service(rusoto_s3::GetObjectError::NoSuchKey(_)) => {
-                    Error::NotFound {
-                        path: key.clone(),
-                        source: e.into(),
-                    }
-                }
-                _ => Error::UnableToGetData {
-                    bucket: self.bucket_name.to_owned(),
-                    path: key.clone(),
-                    source: e,
-                },
-            })?
-            .body
-            .context(NoDataSnafu {
-                bucket: self.bucket_name.to_owned(),
-                path: key.clone(),
-            })?
-            .map_err(move |source| Error::UnableToGetPieceOfData {
-                source,
-                bucket: bucket_name.clone(),
-                path: key.clone(),
-            })
-            .err_into()
-            .boxed();
+        Ok(GetResult::Stream(
+            self.get_object(location, None).await?.boxed(),
+        ))
+    }
 
-        Ok(GetResult::Stream(s))
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        let size_hint = range.end - range.start;
+        let stream = self.get_object(location, Some(range)).await?;
+        collect_bytes(stream, Some(size_hint)).await
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
@@ -536,6 +510,52 @@ impl AmazonS3 {
             permit: Arc::new(permit),
             inner: self.client_unrestricted.clone(),
         }
+    }
+
+    async fn get_object(
+        &self,
+        location: &Path,
+        range: Option<Range<usize>>,
+    ) -> Result<impl Stream<Item = Result<Bytes>>> {
+        let key = location.to_string();
+        let get_request = rusoto_s3::GetObjectRequest {
+            bucket: self.bucket_name.clone(),
+            key: key.clone(),
+            range: range.map(format_range),
+            ..Default::default()
+        };
+        let bucket_name = self.bucket_name.clone();
+        let stream = self
+            .client()
+            .await
+            .get_object(get_request)
+            .await
+            .map_err(|e| match e {
+                rusoto_core::RusotoError::Service(rusoto_s3::GetObjectError::NoSuchKey(_)) => {
+                    Error::NotFound {
+                        path: key.clone(),
+                        source: e.into(),
+                    }
+                }
+                _ => Error::UnableToGetData {
+                    bucket: self.bucket_name.to_owned(),
+                    path: key.clone(),
+                    source: e,
+                },
+            })?
+            .body
+            .context(NoDataSnafu {
+                bucket: self.bucket_name.to_owned(),
+                path: key.clone(),
+            })?
+            .map_err(move |source| Error::UnableToGetPieceOfData {
+                source,
+                bucket: bucket_name.clone(),
+                path: key.clone(),
+            })
+            .err_into();
+
+        Ok(stream)
     }
 
     async fn list_objects_v2(

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,5 +1,5 @@
 //! An object store implementation for S3
-use crate::util::format_range;
+use crate::util::format_http_range;
 use crate::{
     collect_bytes,
     path::{Path, DELIMITER},
@@ -521,7 +521,7 @@ impl AmazonS3 {
         let get_request = rusoto_s3::GetObjectRequest {
             bucket: self.bucket_name.clone(),
             key: key.clone(),
-            range: range.map(format_range),
+            range: range.map(format_http_range),
             ..Default::default()
         };
         let bucket_name = self.bucket_name.clone();

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,6 +1,7 @@
 //! An object store implementation for Google Cloud Storage
 use crate::{
-    path::{format_prefix, Path, DELIMITER},
+    path::{Path, DELIMITER},
+    util::format_prefix,
     GetResult, ListResult, ObjectMeta, ObjectStore, Result,
 };
 use async_trait::async_trait;
@@ -8,6 +9,7 @@ use bytes::Bytes;
 use cloud_storage::{Client, Object};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use snafu::{ResultExt, Snafu};
+use std::ops::Range;
 use std::{convert::TryFrom, env};
 
 /// A specialized `Error` for Google Cloud Storage object store-related errors
@@ -157,6 +159,10 @@ impl ObjectStore for GoogleCloudStorage {
 
         let s = futures::stream::once(async move { Ok(bytes.into()) }).boxed();
         Ok(GetResult::Stream(s))
+    }
+
+    async fn get_range(&self, _location: &Path, _range: Range<usize>) -> Result<Bytes> {
+        Err(super::Error::NotSupported { source: "cloud_storage_rs does not support range requests - https://github.com/ThouCheese/cloud-storage-rs/pull/111".into() })
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,17 @@ pub mod memory;
 pub mod path;
 pub mod throttle;
 
+mod util;
+
 use crate::path::Path;
+use crate::util::collect_bytes;
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use snafu::Snafu;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 
 /// An alias for a dynamically dispatched object store implementation.
 pub type DynObjectStore = dyn ObjectStore;
@@ -52,6 +56,10 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
 
     /// Return the bytes that are stored at the specified location.
     async fn get(&self, location: &Path) -> Result<GetResult>;
+
+    /// Return the bytes that are stored at the specified location
+    /// in the given byte range
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes>;
 
     /// Return the metadata for the specified location
     async fn head(&self, location: &Path) -> Result<ObjectMeta>;
@@ -109,23 +117,16 @@ pub enum GetResult {
 impl Debug for GetResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            GetResult::File(_, _) => write!(f, "GetResult(File)"),
-            GetResult::Stream(_) => write!(f, "GetResult(Stream)"),
+            Self::File(_, _) => write!(f, "GetResult(File)"),
+            Self::Stream(_) => write!(f, "GetResult(Stream)"),
         }
     }
 }
 
 impl GetResult {
-    /// Collects the data into a [`Vec<u8>`]
-    pub async fn bytes(self) -> Result<Vec<u8>> {
-        let mut stream = self.into_stream();
-        let mut bytes = Vec::new();
-
-        while let Some(next) = stream.next().await {
-            bytes.extend_from_slice(next?.as_ref())
-        }
-
-        Ok(bytes)
+    /// Collects the data into a [`Bytes`]
+    pub async fn bytes(self) -> Result<Bytes> {
+        collect_bytes(self.into_stream(), None).await
     }
 
     /// Converts this into a byte stream
@@ -172,6 +173,11 @@ pub enum Error {
         context(false)
     )]
     InvalidPath { source: path::Error },
+
+    #[snafu(display("Operation not supported: {}", source))]
+    NotSupported {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 #[cfg(test)]
@@ -200,6 +206,8 @@ mod tests {
     type Result<T, E = Error> = std::result::Result<T, E>;
 
     pub(crate) async fn put_get_delete_list(storage: &DynObjectStore) -> Result<()> {
+        let store_str = storage.to_string();
+
         delete_fixtures(storage).await;
 
         let content_list = flatten_list_stream(storage, None).await?;
@@ -250,6 +258,23 @@ mod tests {
         let read_data = storage.get(&location).await?.bytes().await?;
         assert_eq!(&*read_data, expected_data);
 
+        // Test range request
+        let range = 3..7;
+        let range_result = storage.get_range(&location, range.clone()).await;
+
+        if store_str.starts_with("GoogleCloudStorage") {
+            // cloud_storage_rs doesn't report range requests (yet)
+            let err = range_result.unwrap_err();
+            assert!(matches!(err, super::Error::NotSupported { .. }), "{}", err);
+        } else if store_str.starts_with("MicrosoftAzureEmulator") {
+            // Azurite doesn't support range requests
+            let err = range_result.unwrap_err().to_string();
+            assert!(err.contains("x-ms-range-get-content-crc64 header or parameter is not supported in Azurite strict mode"), "{}", err);
+        } else {
+            let bytes = range_result.unwrap();
+            assert_eq!(bytes, expected_data.slice(range));
+        }
+
         let head = storage.head(&location).await?;
         assert_eq!(head.size, expected_data.len());
 
@@ -259,7 +284,7 @@ mod tests {
         assert!(content_list.is_empty());
 
         // Azure doesn't report semantic errors
-        let is_azure = storage.to_string().starts_with("MicrosoftAzure");
+        let is_azure = store_str.starts_with("MicrosoftAzure");
 
         let err = storage.get(&location).await.unwrap_err();
         assert!(
@@ -451,7 +476,7 @@ mod tests {
     pub(crate) async fn get_nonexistent_object(
         storage: &DynObjectStore,
         location: Option<Path>,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Bytes> {
         let location = location.unwrap_or_else(|| Path::from("this_file_should_not_exist"));
 
         let err = storage.head(&location).await.unwrap_err();

--- a/src/local.rs
+++ b/src/local.rs
@@ -8,8 +8,11 @@ use futures::{
 };
 use percent_encoding::percent_decode;
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::io::SeekFrom;
+use std::ops::Range;
 use std::{collections::BTreeSet, convert::TryFrom, io};
 use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use url::Url;
 use walkdir::{DirEntry, WalkDir};
 
@@ -82,6 +85,12 @@ pub(crate) enum Error {
 
     #[snafu(display("Unable to canonicalize path {}: {}", path.display(), source))]
     UnableToCanonicalize {
+        source: io::Error,
+        path: std::path::PathBuf,
+    },
+
+    #[snafu(display("Error seeking file {}: {}", path.display(), source))]
+    Seek {
         source: io::Error,
         path: std::path::PathBuf,
     },
@@ -232,6 +241,25 @@ impl ObjectStore for LocalFileSystem {
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let (file, path) = self.get_file(location).await?;
         Ok(GetResult::File(file, path))
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        let (mut file, path) = self.get_file(location).await?;
+
+        let to_read = range.end - range.start;
+        let mut bytes = Vec::with_capacity(to_read);
+
+        file.seek(SeekFrom::Start(range.start as u64))
+            .await
+            .context(SeekSnafu { path: &path })?;
+
+        while bytes.len() != to_read {
+            file.read_buf(&mut bytes)
+                .await
+                .context(UnableToReadBytesSnafu { path: &path })?;
+        }
+
+        Ok(bytes.into())
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,6 +7,7 @@ use futures::{stream::BoxStream, StreamExt};
 use snafu::{OptionExt, Snafu};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::ops::Range;
 use tokio::sync::RwLock;
 
 /// A specialized `Error` for in-memory object store-related errors
@@ -55,6 +56,11 @@ impl ObjectStore for InMemory {
         Ok(GetResult::Stream(
             futures::stream::once(async move { Ok(data) }).boxed(),
         ))
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        let data = self.get_bytes(location).await?;
+        Ok(data.slice(range))
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -214,14 +214,6 @@ where
     }
 }
 
-/// Returns the prefix to be passed to an object store
-#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
-pub(crate) fn format_prefix(prefix: Option<&Path>) -> Option<String> {
-    prefix
-        .filter(|x| !x.as_ref().is_empty())
-        .map(|p| format!("{}{}", p.as_ref(), DELIMITER))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,43 @@
+//! Common logic for interacting with remote object stores
+use super::Result;
+use bytes::Bytes;
+use futures::{stream::StreamExt, Stream};
+
+/// Returns the prefix to be passed to an object store
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+pub fn format_prefix(prefix: Option<&crate::path::Path>) -> Option<String> {
+    prefix
+        .filter(|x| !x.as_ref().is_empty())
+        .map(|p| format!("{}{}", p.as_ref(), crate::path::DELIMITER))
+}
+
+/// Returns the range to be passed to an object store
+#[cfg(any(feature = "aws"))]
+pub fn format_range(range: std::ops::Range<usize>) -> String {
+    format!("bytes={}-{}", range.start, range.end.saturating_sub(1))
+}
+
+/// Collect a stream into [`Bytes`] avoiding copying in the event of a single chunk
+pub async fn collect_bytes<S>(mut stream: S, size_hint: Option<usize>) -> Result<Bytes>
+where
+    S: Stream<Item = Result<Bytes>> + Send + Unpin,
+{
+    let first = stream.next().await.transpose()?.unwrap_or_default();
+
+    // Avoid copying if single response
+    match stream.next().await.transpose()? {
+        None => Ok(first),
+        Some(second) => {
+            let size_hint = size_hint.unwrap_or_else(|| first.len() + second.len());
+
+            let mut buf = Vec::with_capacity(size_hint);
+            buf.extend_from_slice(&first);
+            buf.extend_from_slice(&second);
+            while let Some(maybe_bytes) = stream.next().await {
+                buf.extend_from_slice(&maybe_bytes?);
+            }
+
+            Ok(buf.into())
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,9 +11,10 @@ pub fn format_prefix(prefix: Option<&crate::path::Path>) -> Option<String> {
         .map(|p| format!("{}{}", p.as_ref(), crate::path::DELIMITER))
 }
 
-/// Returns the range to be passed to an object store
+/// Returns a formatted HTTP range header as per
+/// <https://httpwg.org/specs/rfc7233.html#header.range>
 #[cfg(any(feature = "aws"))]
-pub fn format_range(range: std::ops::Range<usize>) -> String {
+pub fn format_http_range(range: std::ops::Range<usize>) -> String {
     format!("bytes={}-{}", range.start, range.end.saturating_sub(1))
 }
 


### PR DESCRIPTION
This adds support for range requests, unfortunately:

* Azurite doesn't support emulating these (I intend to verify against a real Azure bucket prior to merge)
* The crate we use for GCS doesn't support range requests - https://github.com/ThouCheese/cloud-storage-rs/pull/111

*I personally wonder about just rolling our own GCS crate, it is a really straightforward API, with simple token-based auth, and #14 also runs into limitations of this crate*