### PR TITLE
feat: consistently handle blocking IO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,7 @@ rusoto_core = { version = "0.48.0", optional = true, default-features = false, f
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }
 rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 snafu = "0.7"
-tokio = { version = "1.18", features = ["fs", "io-util", "macros", "parking_lot", "rt-multi-thread", "time"] }
-# Filesystem integration
-tokio-util = { version = "0.7.1", features = ["codec", "io"] }
+tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time"] }
 tracing = { version = "0.1" }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["rustls-tls"] }
 # Filesystem integration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ impl GetResult {
     /// Tokio discourages performing blocking IO on a tokio worker thread, however,
     /// no major operating systems have stable async file APIs. Therefore if called from
     /// a tokio context, this will use [`tokio::runtime::Handle::spawn_blocking`] to dispatch
-    /// IO to a blocking thread pool, much like [`tokio::fs`] does under-the-hood.
+    /// IO to a blocking thread pool, much like `tokio::fs` does under-the-hood.
     ///
     /// If not called from a tokio context, this will perform IO on the current thread with
     /// no additional complexity or overheads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,14 @@ pub mod throttle;
 mod util;
 
 use crate::path::Path;
-use crate::util::collect_bytes;
+use crate::util::{collect_bytes, maybe_spawn_blocking};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use snafu::Snafu;
 use std::fmt::{Debug, Formatter};
+use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
 
 /// An alias for a dynamically dispatched object store implementation.
@@ -109,7 +110,7 @@ pub struct ObjectMeta {
 /// Result for a get request
 pub enum GetResult {
     /// A file and its path on the local filesystem
-    File(tokio::fs::File, std::path::PathBuf),
+    File(std::fs::File, std::path::PathBuf),
     /// An asynchronous stream
     Stream(BoxStream<'static, Result<Bytes>>),
 }
@@ -126,23 +127,69 @@ impl Debug for GetResult {
 impl GetResult {
     /// Collects the data into a [`Bytes`]
     pub async fn bytes(self) -> Result<Bytes> {
-        collect_bytes(self.into_stream(), None).await
+        match self {
+            Self::File(mut file, path) => {
+                maybe_spawn_blocking(move || {
+                    let len = file
+                        .seek(SeekFrom::End(0))
+                        .map_err(|source| local::Error::Seek {
+                            source,
+                            path: path.clone(),
+                        })?;
+
+                    file.seek(SeekFrom::Start(0))
+                        .map_err(|source| local::Error::Seek {
+                            source,
+                            path: path.clone(),
+                        })?;
+
+                    let mut buffer = Vec::with_capacity(len as usize);
+                    file.read_to_end(&mut buffer)
+                        .map_err(|source| local::Error::UnableToReadBytes { source, path })?;
+
+                    Ok(buffer.into())
+                })
+                .await
+            }
+            Self::Stream(s) => collect_bytes(s, None).await,
+        }
     }
 
     /// Converts this into a byte stream
+    ///
+    /// If the result is [`Self::File`] will perform chunked reads of the file, otherwise
+    /// will return the [`Self::Stream`].
+    ///
+    /// # Blocking Behaviour
+    ///
+    /// If called from a tokio context, will use [`tokio::runtime::Handle::spawn_blocking`] to
+    /// spawn the blocking work to a background thread, otherwise will perform potentially
+    /// blocking IO on the current thread
     pub fn into_stream(self) -> BoxStream<'static, Result<Bytes>> {
         match self {
             Self::File(file, path) => {
-                tokio_util::codec::FramedRead::new(file, tokio_util::codec::BytesCodec::new())
-                    .map_ok(|b| b.freeze())
-                    .map_err(move |source| {
-                        local::Error::UnableToReadBytes {
-                            source,
-                            path: path.clone(),
+                const CHUNK_SIZE: usize = 8 * 1024;
+
+                futures::stream::try_unfold((file, path, false), |(mut file, path, finished)| {
+                    maybe_spawn_blocking(move || {
+                        if finished {
+                            return Ok(None);
                         }
-                        .into()
+
+                        let mut buffer = Vec::with_capacity(CHUNK_SIZE);
+                        let read = file
+                            .by_ref()
+                            .take(CHUNK_SIZE as u64)
+                            .read_to_end(&mut buffer)
+                            .map_err(|e| local::Error::UnableToReadBytes {
+                                source: e,
+                                path: path.clone(),
+                            })?;
+
+                        Ok(Some((buffer.into(), (file, path, read != CHUNK_SIZE))))
                     })
-                    .boxed()
+                })
+                .boxed()
             }
             Self::Stream(s) => s,
         }
@@ -174,6 +221,9 @@ pub enum Error {
     )]
     InvalidPath { source: path::Error },
 
+    #[snafu(display("Error joining spawned task: {}", source), context(false))]
+    JoinError { source: tokio::task::JoinError },
+
     #[snafu(display("Operation not supported: {}", source))]
     NotSupported {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
@@ -183,6 +233,7 @@ pub enum Error {
 #[cfg(test)]
 mod test_util {
     use super::*;
+    use futures::TryStreamExt;
 
     pub async fn flatten_list_stream(
         storage: &DynObjectStore,

--- a/src/local.rs
+++ b/src/local.rs
@@ -136,7 +136,7 @@ impl From<Error> for super::Error {
 /// Tokio discourages performing blocking IO on a tokio worker thread, however,
 /// no major operating systems have stable async file APIs. Therefore if called from
 /// a tokio context, this will use [`tokio::runtime::Handle::spawn_blocking`] to dispatch
-/// IO to a blocking thread pool, much like [`tokio::fs`] does under-the-hood.
+/// IO to a blocking thread pool, much like `tokio::fs` does under-the-hood.
 ///
 /// If not called from a tokio context, this will perform IO on the current thread with
 /// no additional complexity or overheads

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,3 +42,15 @@ where
         }
     }
 }
+
+/// Takes a function and spawns it to a tokio blocking pool if available
+pub async fn maybe_spawn_blocking<F, T>(f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(runtime) => runtime.spawn_blocking(f).await?,
+        Err(_) => f(),
+    }
+}


### PR DESCRIPTION
Previously LocalFileSystem would perform a mixture of blocking IO (walkdir) and non-blocking IO (tokio::fs).

As previously documented in https://github.com/apache/arrow-rs/issues/1473, the tokio filesystem APIs can impose pretty severe overheads as they call spawn_blocking for every operation. This PR therefore does the following:

* Adds a maybe_spawn_blocking API that will call spawn_blocking if the current thread is a tokio context, falling back to blocking locally if not
* Wraps the top-level LocalFileSystem APIs with `maybe_spawn_blocking`

This ensures that when running from a tokio context, the cost of spawn_blocking is amortised, and when not running in a tokio context we pay no additional cost.

I recommend reviewing with whitespace ignored - https://github.com/influxdata/object_store_rs/pull/17/files?w=1