### PR TITLE
feat: Add stream upload (multi-part upload)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
+serde-xml-rs = { version = "0.5.1", default-features = false, optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 ring = { version = "0.16", default-features = false, features = ["std"] }
 base64 = { version = "0.13", default-features = false, optional = true }
@@ -53,7 +54,7 @@ walkdir = "2"
 [features]
 azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest"]
 azure_test = ["azure", "azure_core/azurite_workaround", "azure_storage/azurite_workaround", "azure_storage_blobs/azurite_workaround"]
-gcp = ["serde", "serde_json", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64"]
+gcp = ["serde", "serde_json", "serde-xml-rs", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64"]
 aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "hyper", "hyper-rustls"]
 
 [dev-dependencies] # In alphabetical order

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ hyper = { version = "0.14", optional = true, default-features = false }
 hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = ["webpki-tokio", "http1", "http2", "tls12"] }
 itertools = "0.10.1"
 percent-encoding = "2.1"
-pin-project = "1.0"
 # rusoto crates are for Amazon S3 integration
 rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,14 @@ hyper = { version = "0.14", optional = true, default-features = false }
 hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = ["webpki-tokio", "http1", "http2", "tls12"] }
 itertools = "0.10.1"
 percent-encoding = "2.1"
+pin-project = "1.0"
 # rusoto crates are for Amazon S3 integration
 rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }
 rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"]  }
 snafu = "0.7"
-tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time"] }
+tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time", "io-util"] }
 tracing = { version = "0.1" }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["rustls-tls"] }
 parking_lot = { version = "0.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
-serde-xml-rs = { version = "0.5.1", default-features = false, optional = true }
+quick-xml = { version = "0.23.0", features = ["serialize"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 ring = { version = "0.16", default-features = false, features = ["std"] }
 base64 = { version = "0.13", default-features = false, optional = true }
@@ -54,7 +54,7 @@ walkdir = "2"
 [features]
 azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest"]
 azure_test = ["azure", "azure_core/azurite_workaround", "azure_storage/azurite_workaround", "azure_storage_blobs/azurite_workaround"]
-gcp = ["serde", "serde_json", "serde-xml-rs", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64"]
+gcp = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64"]
 aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "hyper", "hyper-rustls"]
 
 [dev-dependencies] # In alphabetical order

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -7,7 +7,7 @@
 //! requirements for a part. Multiple parts are uploaded concurrently.
 //!
 //! If the writer fails for any reason, you may have parts uploaded to AWS but not
-//! used that you may be charged for. Use the [ObjectStore::cleanup_multipart] method
+//! used that you may be charged for. Use the [ObjectStore::abort_multipart] method
 //! to abort the upload and drop those unneeded parts. In addition, you may wish to
 //! consider implementing [automatic cleanup] of unused parts that are older than one
 //! week.
@@ -328,7 +328,7 @@ impl ObjectStore for AmazonS3 {
         Ok((upload_id, Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
         let request_factory = move || rusoto_s3::AbortMultipartUploadRequest {
             bucket: self.bucket_name.clone(),
             key: location.to_string(),

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -326,11 +326,11 @@ impl ObjectStore for AmazonS3 {
         Ok((upload_id, Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, upload_id: &MultipartId) -> Result<()> {
+    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
         let request_factory = move || rusoto_s3::AbortMultipartUploadRequest {
             bucket: self.bucket_name.clone(),
             key: location.to_string(),
-            upload_id: upload_id.to_string(),
+            upload_id: multipart_id.to_string(),
             ..Default::default()
         };
 

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -9,8 +9,10 @@
 //! If the writer fails for any reason, you may have parts uploaded to AWS but not
 //! used that you may be charged for. Use the [ObjectStore::cleanup_multipart] method
 //! to abort the upload and drop those unneeded parts. In addition, you may wish to
-//! consider implementing automatic clean up of unused parts that are older than one
+//! consider implementing [automatic cleanup] of unused parts that are older than one
 //! week.
+//!
+//! [automatic cleanup]: https://aws.amazon.com/blogs/aws/s3-lifecycle-management-update-support-for-multipart-uploads-and-delete-markers/
 use crate::multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart};
 use crate::util::format_http_range;
 use crate::MultipartId;
@@ -915,8 +917,7 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
         let connection_semaphore = Arc::clone(&self.connection_semaphore);
 
         Box::pin(async move {
-            #[allow(unused_variables)]
-            let permit = connection_semaphore
+            let _permit = connection_semaphore
                 .acquire_owned()
                 .await
                 .expect("semaphore shouldn't be closed yet");
@@ -980,8 +981,7 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
         let connection_semaphore = Arc::clone(&self.connection_semaphore);
 
         Box::pin(async move {
-            #[allow(unused_variables)]
-            let permit = connection_semaphore
+            let _permit = connection_semaphore
                 .acquire_owned()
                 .await
                 .expect("semaphore shouldn't be closed yet");

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -336,7 +336,7 @@ impl ObjectStore for AmazonS3 {
 
         let s3 = self.client().await;
         s3_request(move || {
-            let (s3, request_factory) = (s3.clone(), request_factory.clone());
+            let (s3, request_factory) = (s3.clone(), request_factory);
 
             async move { s3.abort_multipart_upload(request_factory()).await }
         })

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -223,7 +223,7 @@ impl ObjectStore for MicrosoftAzure {
         Ok((String::new(), Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _upload_id: &MultipartId) -> Result<()> {
+    async fn cleanup_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // There is no way to drop blocks that have been uploaded. Instead, they simply
         // expire in 7 days.
         Ok(())
@@ -557,9 +557,9 @@ pub fn new_azure(
 
 // Relevant docs: https://azure.github.io/Storage/docs/application-and-user-data/basics/azure-blob-storage-upload-apis/
 // In Azure Blob Store, parts are "blocks"
-// upload_part -> PUT block
-// complete_upload -> PUT block list
-// abort_upload -> No equivalent; blocks are simply dropped after 7 days
+// put_multipart_part -> PUT block
+// complete -> PUT block list
+// abort -> No equivalent; blocks are simply dropped after 7 days
 #[derive(Debug, Clone)]
 struct AzureMultiPartUpload {
     container_client: Arc<ContainerClient>,

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -6,7 +6,7 @@
 //! blocks. Data is buffered internally to make blocks of at least 5MB and blocks
 //! are uploaded concurrently.
 //!
-//! [ObjectStore::cleanup_multipart] is a no-op, since Azure Blob Store doesn't provide
+//! [ObjectStore::abort_multipart] is a no-op, since Azure Blob Store doesn't provide
 //! a way to drop old blocks. Instead unused blocks are automatically cleaned up
 //! after 7 days.
 use crate::{
@@ -223,7 +223,7 @@ impl ObjectStore for MicrosoftAzure {
         Ok((String::new(), Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // There is no way to drop blocks that have been uploaded. Instead, they simply
         // expire in 7 days.
         Ok(())

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -1,4 +1,14 @@
 //! An object store implementation for Azure blob storage
+//!
+//! ## Streaming uploads
+//!
+//! [ObjectStore::upload] will upload data in blocks and write a blob from those
+//! blocks. Data is buffered internally to make blocks of at least 5MB and blocks
+//! are uploaded concurrently.
+//!
+//! [ObjectStore::cleanup_upload] is a no-op, since Azure Blob Store doesn't provide
+//! a way to drop old blocks. Instead unused blocks are automatically cleaned up
+//! after 7 days.
 use crate::{
     multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart},
     path::{Path, DELIMITER},

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -19,7 +19,7 @@ use crate::{
     path::{Path, DELIMITER},
     token::TokenCache,
     util::format_prefix,
-    GetResult, ListResult, ObjectMeta, ObjectStore, Result,
+    GetResult, ListResult, MultiPartUpload, ObjectMeta, ObjectStore, Result,
 };
 
 #[derive(Debug, Snafu)]
@@ -376,6 +376,12 @@ impl GoogleCloudStorage {
 impl ObjectStore for GoogleCloudStorage {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.put_request(location, bytes).await
+    }
+
+    async fn upload(&self, _location: &Path) -> Result<Box<dyn MultiPartUpload>> {
+        // TODO: cloud_storage does not provide any bindings for multi-part upload.
+        // But GCS does support this.
+        Err(super::Error::NotImplemented)
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -12,6 +12,7 @@ use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::RANGE;
 use reqwest::{header, Client, Method, Response, StatusCode};
 use snafu::{ResultExt, Snafu};
+use tokio::io::AsyncWrite;
 
 use crate::util::format_http_range;
 use crate::{
@@ -19,7 +20,7 @@ use crate::{
     path::{Path, DELIMITER},
     token::TokenCache,
     util::format_prefix,
-    GetResult, ListResult, MultiPartUpload, ObjectMeta, ObjectStore, Result,
+    GetResult, ListResult, ObjectMeta, ObjectStore, Result, UploadId,
 };
 
 #[derive(Debug, Snafu)]
@@ -378,9 +379,16 @@ impl ObjectStore for GoogleCloudStorage {
         self.put_request(location, bytes).await
     }
 
-    async fn upload(&self, _location: &Path) -> Result<Box<dyn MultiPartUpload>> {
+    async fn upload(
+        &self,
+        _location: &Path,
+    ) -> Result<(UploadId, Box<dyn AsyncWrite + Unpin + Send>)> {
         // TODO: cloud_storage does not provide any bindings for multi-part upload.
         // But GCS does support this.
+        Err(super::Error::NotImplemented)
+    }
+
+    async fn cleanup_upload(&self, _location: &Path, _upload_id: &UploadId) -> Result<()> {
         Err(super::Error::NotImplemented)
     }
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -20,7 +20,7 @@ use crate::{
     path::{Path, DELIMITER},
     token::TokenCache,
     util::format_prefix,
-    GetResult, ListResult, ObjectMeta, ObjectStore, Result, UploadId,
+    GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result,
 };
 
 #[derive(Debug, Snafu)]
@@ -379,16 +379,16 @@ impl ObjectStore for GoogleCloudStorage {
         self.put_request(location, bytes).await
     }
 
-    async fn upload(
+    async fn put_multipart(
         &self,
         _location: &Path,
-    ) -> Result<(UploadId, Box<dyn AsyncWrite + Unpin + Send>)> {
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
         // TODO: cloud_storage does not provide any bindings for multi-part upload.
         // But GCS does support this.
         Err(super::Error::NotImplemented)
     }
 
-    async fn cleanup_upload(&self, _location: &Path, _upload_id: &UploadId) -> Result<()> {
+    async fn cleanup_multipart(&self, _location: &Path, _upload_id: &MultipartId) -> Result<()> {
         Err(super::Error::NotImplemented)
     }
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -166,7 +166,7 @@ struct CompleteMultipartUpload {
     parts: Vec<MultipartPart>,
 }
 
-/// Configuration for connecting to [Google Cloud Storage](https://cloud.google.com/storage/).s
+/// Configuration for connecting to [Google Cloud Storage](https://cloud.google.com/storage/).
 #[derive(Debug)]
 pub struct GoogleCloudStorage {
     client: Arc<GoogleCloudStorageClient>,
@@ -473,8 +473,6 @@ impl GoogleCloudStorageClient {
 fn reqwest_error_as_io(err: reqwest::Error) -> io::Error {
     if err.is_builder() || err.is_request() {
         io::Error::new(io::ErrorKind::InvalidInput, err)
-    } else if err.is_redirect() {
-        io::Error::new(io::ErrorKind::ConnectionAborted, err)
     } else if err.is_status() {
         match err.status() {
             Some(StatusCode::NOT_FOUND) => io::Error::new(io::ErrorKind::NotFound, err),
@@ -867,6 +865,7 @@ mod test {
         rename_and_copy(&integration).await.unwrap();
         if integration.client.base_url == default_gcs_base_url() {
             // Fake GCS server does not yet implement XML Multipart uploads
+            // https://github.com/fsouza/fake-gcs-server/issues/852
             stream_get(&integration).await.unwrap();
         }
     }

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,12 +1,27 @@
 //! An object store implementation for Google Cloud Storage
+//!
+//! ## Multi-part uploads
+//!
+//! [Multi-part uploads](https://cloud.google.com/storage/docs/multipart-uploads)
+//! can be initiated with the [ObjectStore::put_multipart] method.
+//! Data passed to the writer is automatically buffered to meet the minimum size
+//! requirements for a part. Multiple parts are uploaded concurrently.
+//!
+//! If the writer fails for any reason, you may have parts uploaded to GCS but not
+//! used that you may be charged for. Use the [ObjectStore::cleanup_multipart] method
+//! to abort the upload and drop those unneeded parts. In addition, you may wish to
+//! consider implementing automatic clean up of unused parts that are older than one
+//! week.
 use std::collections::BTreeSet;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{self, BufReader};
 use std::ops::Range;
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use chrono::{DateTime, Utc};
+use futures::future::BoxFuture;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::RANGE;
@@ -14,6 +29,7 @@ use reqwest::{header, Client, Method, Response, StatusCode};
 use snafu::{ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 
+use crate::multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart};
 use crate::util::format_http_range;
 use crate::{
     oauth::OAuthProvider,
@@ -30,6 +46,13 @@ enum Error {
 
     #[snafu(display("Unable to decode service account file: {}", source))]
     DecodeCredentials { source: serde_json::Error },
+
+    #[snafu(display("Got invalid XML response for {} {}: {}", method, url, source))]
+    InvalidXMLResponse {
+        source: serde_xml_rs::Error,
+        method: String,
+        url: String,
+    },
 
     #[snafu(display("Error performing list request: {}", source))]
     ListRequest { source: reqwest::Error },
@@ -123,9 +146,39 @@ struct Object {
     updated: DateTime<Utc>,
 }
 
-/// Configuration for connecting to [Google Cloud Storage](https://cloud.google.com/storage/).
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct InitiateMultipartUploadResult<'a> {
+    upload_id: &'a str,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase", rename(serialize = "Part"))]
+struct MultipartPart {
+    part_number: usize,
+    e_tag: String,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CompleteMultipartUpload {
+    parts: Vec<MultipartPart>,
+}
+
+/// Configuration for connecting to [Google Cloud Storage](https://cloud.google.com/storage/).s
 #[derive(Debug)]
 pub struct GoogleCloudStorage {
+    client: Arc<GoogleCloudStorageClient>,
+}
+
+impl std::fmt::Display for GoogleCloudStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GoogleCloudStorage({})", self.client.bucket_name)
+    }
+}
+
+#[derive(Debug)]
+struct GoogleCloudStorageClient {
     client: Client,
     base_url: String,
 
@@ -139,13 +192,7 @@ pub struct GoogleCloudStorage {
     max_list_results: Option<String>,
 }
 
-impl std::fmt::Display for GoogleCloudStorage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "GoogleCloudStorage({})", self.bucket_name)
-    }
-}
-
-impl GoogleCloudStorage {
+impl GoogleCloudStorageClient {
     async fn get_token(&self) -> Result<String> {
         if let Some(oauth_provider) = &self.oauth_provider {
             Ok(self
@@ -217,6 +264,54 @@ impl GoogleCloudStorage {
             .header(header::CONTENT_LENGTH, payload.len())
             .query(&[("uploadType", "media"), ("name", path.as_ref())])
             .body(payload)
+            .send()
+            .await
+            .context(PutRequestSnafu)?
+            .error_for_status()
+            .context(PutRequestSnafu)?;
+
+        Ok(())
+    }
+
+    /// Initiate a multi-part upload <https://cloud.google.com/storage/docs/xml-api/post-object-multipart>
+    async fn multipart_initiate(&self, path: &Path) -> Result<MultipartId> {
+        let token = self.get_token().await?;
+        let url = format!("{}/{}/{}", self.base_url, self.bucket_name_encoded, path);
+
+        let response = self
+            .client
+            .request(Method::POST, &url)
+            .bearer_auth(token)
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header(header::CONTENT_LENGTH, "0")
+            .query(&[("uploads", "")])
+            .send()
+            .await
+            .context(PutRequestSnafu)?
+            .error_for_status()
+            .context(PutRequestSnafu)?;
+
+        let data = response.bytes().await.context(PutRequestSnafu)?;
+        let result: InitiateMultipartUploadResult<'_> = serde_xml_rs::from_reader(data.reader())
+            .context(InvalidXMLResponseSnafu {
+                method: "POST".to_string(),
+                url,
+            })?;
+
+        Ok(result.upload_id.to_string())
+    }
+
+    /// Cleanup unused parts <https://cloud.google.com/storage/docs/xml-api/delete-multipart>
+    async fn multipart_cleanup(&self, path: &str, multipart_id: &MultipartId) -> Result<()> {
+        let token = self.get_token().await?;
+        let url = format!("{}/{}/{}", self.base_url, self.bucket_name_encoded, path);
+
+        self.client
+            .request(Method::DELETE, &url)
+            .bearer_auth(token)
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header(header::CONTENT_LENGTH, "0")
+            .query(&[("uploadId", multipart_id)])
             .send()
             .await
             .context(PutRequestSnafu)?
@@ -373,27 +468,171 @@ impl GoogleCloudStorage {
     }
 }
 
+fn reqwest_error_as_io(err: reqwest::Error) -> io::Error {
+    if err.is_builder() || err.is_request() {
+        io::Error::new(io::ErrorKind::InvalidInput, err)
+    } else if err.is_redirect() {
+        io::Error::new(io::ErrorKind::ConnectionAborted, err)
+    } else if err.is_status() {
+        match err.status() {
+            Some(StatusCode::NOT_FOUND) => io::Error::new(io::ErrorKind::NotFound, err),
+            Some(StatusCode::BAD_REQUEST) => io::Error::new(io::ErrorKind::InvalidInput, err),
+            Some(_) => io::Error::new(io::ErrorKind::Other, err),
+            None => io::Error::new(io::ErrorKind::Other, err),
+        }
+    } else if err.is_timeout() {
+        io::Error::new(io::ErrorKind::TimedOut, err)
+    } else if err.is_connect() {
+        io::Error::new(io::ErrorKind::NotConnected, err)
+    } else {
+        io::Error::new(io::ErrorKind::Other, err)
+    }
+}
+
+struct GCSMultipartUpload {
+    client: Arc<GoogleCloudStorageClient>,
+    encoded_path: String,
+    upload_id: MultipartId,
+}
+
+impl CloudMultiPartUploadImpl for GCSMultipartUpload {
+    /// Upload an object part <https://cloud.google.com/storage/docs/xml-api/put-object-multipart>
+    fn put_multipart_part(
+        &self,
+        buf: Vec<u8>,
+        part_idx: usize,
+    ) -> BoxFuture<'static, Result<(usize, UploadPart), io::Error>> {
+        let upload_id = self.upload_id.clone();
+        let url = format!(
+            "{}/{}/{}",
+            self.client.base_url, self.client.bucket_name_encoded, self.encoded_path
+        );
+        let client = Arc::clone(&self.client);
+
+        Box::pin(async move {
+            let token = client
+                .get_token()
+                .await
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            let response = client
+                .client
+                .request(Method::PUT, &url)
+                .bearer_auth(token)
+                .query(&[(
+                    "partNumber",
+                    format!("{}", part_idx),
+                    ("uploadId", upload_id),
+                )])
+                .header(header::CONTENT_TYPE, "application/octet-stream")
+                .header(header::CONTENT_LENGTH, format!("{}", buf.len()))
+                .body(buf)
+                .send()
+                .await
+                .map_err(reqwest_error_as_io)?
+                .error_for_status()
+                .map_err(reqwest_error_as_io)?;
+
+            let content_id = response
+                .headers()
+                .get("ETag")
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "response headers missing ETag")
+                })?
+                .to_str()
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+                .to_string();
+
+            Ok((part_idx, UploadPart { content_id }))
+        })
+    }
+
+    /// Complete a multipart upload <https://cloud.google.com/storage/docs/xml-api/post-object-complete>
+    fn complete(
+        &self,
+        completed_parts: Vec<Option<UploadPart>>,
+    ) -> BoxFuture<'static, Result<(), io::Error>> {
+        let client = Arc::clone(&self.client);
+        let upload_id = self.upload_id.clone();
+        let url = format!(
+            "{}/{}/{}",
+            self.client.base_url, self.client.bucket_name_encoded, self.encoded_path
+        );
+
+        Box::pin(async move {
+            let parts: Vec<MultipartPart> = completed_parts
+                .into_iter()
+                .enumerate()
+                .map(|(part_number, maybe_part)| match maybe_part {
+                    Some(part) => Ok(MultipartPart {
+                        e_tag: part.content_id,
+                        part_number: part_number + 1,
+                    }),
+                    None => Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("Missing information for upload part {:?}", part_number),
+                    )),
+                })
+                .collect::<Result<Vec<MultipartPart>, io::Error>>()?;
+
+            let token = client
+                .get_token()
+                .await
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+            let data = serde_xml_rs::to_string(&parts)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+            client
+                .client
+                .request(Method::POST, &url)
+                .bearer_auth(token)
+                .query(&[("uploadId", upload_id)])
+                .body(data)
+                .send()
+                .await
+                .map_err(reqwest_error_as_io)?
+                .error_for_status()
+                .map_err(reqwest_error_as_io)?;
+
+            Ok(())
+        })
+    }
+}
+
 #[async_trait]
 impl ObjectStore for GoogleCloudStorage {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        self.put_request(location, bytes).await
+        self.client.put_request(location, bytes).await
     }
 
     async fn put_multipart(
         &self,
-        _location: &Path,
+        location: &Path,
     ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        // TODO: cloud_storage does not provide any bindings for multi-part upload.
-        // But GCS does support this.
-        Err(super::Error::NotImplemented)
+        let upload_id = self.client.multipart_initiate(location).await?;
+
+        let encoded_path =
+            percent_encode(location.to_string().as_bytes(), NON_ALPHANUMERIC).to_string();
+
+        let inner = GCSMultipartUpload {
+            client: Arc::clone(&self.client),
+            encoded_path,
+            upload_id: upload_id.clone(),
+        };
+
+        Ok((upload_id, Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _upload_id: &MultipartId) -> Result<()> {
-        Err(super::Error::NotImplemented)
+    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+        self.client
+            .multipart_cleanup(location.as_ref(), multipart_id)
+            .await?;
+
+        Ok(())
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {
-        let response = self.get_request(location, None, false).await?;
+        let response = self.client.get_request(location, None, false).await?;
         let stream = response
             .bytes_stream()
             .map_err(|source| crate::Error::Generic {
@@ -406,14 +645,17 @@ impl ObjectStore for GoogleCloudStorage {
     }
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
-        let response = self.get_request(location, Some(range), false).await?;
+        let response = self
+            .client
+            .get_request(location, Some(range), false)
+            .await?;
         Ok(response.bytes().await.context(GetRequestSnafu {
             path: location.as_ref(),
         })?)
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let response = self.get_request(location, None, true).await?;
+        let response = self.client.get_request(location, None, true).await?;
         let object = response.json().await.context(GetRequestSnafu {
             path: location.as_ref(),
         })?;
@@ -421,11 +663,12 @@ impl ObjectStore for GoogleCloudStorage {
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        self.delete_request(location).await
+        self.client.delete_request(location).await
     }
 
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let stream = self
+            .client
             .list_paginated(prefix, false)?
             .map_ok(|r| futures::stream::iter(r.items.into_iter().map(|x| convert_object_meta(&x))))
             .try_flatten()
@@ -435,7 +678,7 @@ impl ObjectStore for GoogleCloudStorage {
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
-        let mut stream = self.list_paginated(prefix, true)?;
+        let mut stream = self.client.list_paginated(prefix, true)?;
 
         let mut common_prefixes = BTreeSet::new();
         let mut objects = Vec::new();
@@ -460,11 +703,11 @@ impl ObjectStore for GoogleCloudStorage {
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.copy_request(from, to, false).await
+        self.client.copy_request(from, to, false).await
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.copy_request(from, to, true).await
+        self.client.copy_request(from, to, true).await
     }
 }
 
@@ -506,13 +749,15 @@ pub fn new_gcs(
     // environment variables. Set the environment variable explicitly so
     // that we can optionally accept command line arguments instead.
     Ok(GoogleCloudStorage {
-        client,
-        base_url: credentials.gcs_base_url,
-        oauth_provider,
-        token_cache: Default::default(),
-        bucket_name,
-        bucket_name_encoded: encoded_bucket_name,
-        max_list_results: None,
+        client: Arc::new(GoogleCloudStorageClient {
+            client,
+            base_url: credentials.gcs_base_url,
+            oauth_provider,
+            token_cache: Default::default(),
+            bucket_name,
+            bucket_name_encoded: encoded_bucket_name,
+            max_list_results: None,
+        }),
     })
 }
 
@@ -537,7 +782,7 @@ mod test {
     use crate::{
         tests::{
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
-            put_get_delete_list, rename_and_copy,
+            put_get_delete_list, rename_and_copy, stream_get,
         },
         Error as ObjectStoreError, ObjectStore,
     };
@@ -605,6 +850,7 @@ mod test {
         list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
         rename_and_copy(&integration).await.unwrap();
+        stream_get(&integration).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -8,7 +8,7 @@
 //! requirements for a part. Multiple parts are uploaded concurrently.
 //!
 //! If the writer fails for any reason, you may have parts uploaded to GCS but not
-//! used that you may be charged for. Use the [ObjectStore::cleanup_multipart] method
+//! used that you may be charged for. Use the [ObjectStore::abort_multipart] method
 //! to abort the upload and drop those unneeded parts. In addition, you may wish to
 //! consider implementing automatic clean up of unused parts that are older than one
 //! week.
@@ -634,7 +634,7 @@ impl ObjectStore for GoogleCloudStorage {
         Ok((upload_id, Box::new(CloudMultiPartUpload::new(inner, 8))))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
         self.client
             .multipart_cleanup(location.as_ref(), multipart_id)
             .await?;

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -865,7 +865,10 @@ mod test {
         list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
         rename_and_copy(&integration).await.unwrap();
-        stream_get(&integration).await.unwrap();
+        if integration.client.base_url == default_gcs_base_url() {
+            // Fake GCS server does not yet implement XML Multipart uploads
+            stream_get(&integration).await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -494,7 +494,7 @@ fn reqwest_error_as_io(err: reqwest::Error) -> io::Error {
 struct GCSMultipartUpload {
     client: Arc<GoogleCloudStorageClient>,
     encoded_path: String,
-    upload_id: MultipartId,
+    multipart_id: MultipartId,
 }
 
 impl CloudMultiPartUploadImpl for GCSMultipartUpload {
@@ -504,7 +504,7 @@ impl CloudMultiPartUploadImpl for GCSMultipartUpload {
         buf: Vec<u8>,
         part_idx: usize,
     ) -> BoxFuture<'static, Result<(usize, UploadPart), io::Error>> {
-        let upload_id = self.upload_id.clone();
+        let upload_id = self.multipart_id.clone();
         let url = format!(
             "{}/{}/{}",
             self.client.base_url, self.client.bucket_name_encoded, self.encoded_path
@@ -554,7 +554,7 @@ impl CloudMultiPartUploadImpl for GCSMultipartUpload {
         completed_parts: Vec<Option<UploadPart>>,
     ) -> BoxFuture<'static, Result<(), io::Error>> {
         let client = Arc::clone(&self.client);
-        let upload_id = self.upload_id.clone();
+        let upload_id = self.multipart_id.clone();
         let url = format!(
             "{}/{}/{}",
             self.client.base_url, self.client.bucket_name_encoded, self.encoded_path
@@ -632,10 +632,8 @@ impl ObjectStore for GoogleCloudStorage {
         let inner = GCSMultipartUpload {
             client: Arc::clone(&self.client),
             encoded_path,
-            upload_id: upload_id.clone(),
+            multipart_id: upload_id.clone(),
         };
-
-        dbg!(&upload_id);
 
         Ok((upload_id, Box::new(CloudMultiPartUpload::new(inner, 8))))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,13 @@
 //!
 //! This crate provides APIs for interacting with object storage services.
 //!
-//! It currently supports PUT, GET, DELETE, HEAD and list for:
+//! It currently supports PUT (single or chunked/concurrent), GET, DELETE, HEAD and list for:
 //!
 //! * [Google Cloud Storage](https://cloud.google.com/storage/)
 //! * [Amazon S3](https://aws.amazon.com/s3/)
 //! * [Azure Blob Storage](https://azure.microsoft.com/en-gb/services/storage/blobs/#overview)
 //! * In-memory
 //! * Local file storage
-//!
-//! It also supports streaming writes (multi-part upload) for all except GCS.
-//! (GCS support coming soon!)
 
 #[cfg(feature = "aws")]
 pub mod aws;
@@ -41,7 +38,7 @@ mod oauth;
 #[cfg(feature = "gcp")]
 mod token;
 
-#[cfg(any(feature = "azure", feature = "aws"))]
+#[cfg(any(feature = "azure", feature = "aws", feature = "gcp"))]
 mod multipart;
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! * [Azure Blob Storage](https://azure.microsoft.com/en-gb/services/storage/blobs/#overview)
 //! * In-memory
 //! * Local file storage
+//!
 
 #[cfg(feature = "aws")]
 pub mod aws;
@@ -520,7 +521,7 @@ mod tests {
         assert_eq!(bytes_expected, bytes_written);
 
         // Can overwrite some storage
-        let data = get_vec_of_bytes(5_000_000, 5);
+        let data = get_vec_of_bytes(5_000, 5);
         let bytes_expected = data.concat();
         let (_, mut writer) = storage.put_multipart(&location).await?;
         for chunk in &data {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     ///
     /// See documentation for individual stores for exact behavior, as capabilities
     /// vary by object store.
-    async fn cleanup_multipart(&self, location: &Path, upload_id: &MultipartId) -> Result<()>;
+    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()>;
 
     /// Return the bytes that are stored at the specified location.
     async fn get(&self, location: &Path) -> Result<GetResult>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,15 @@ mod tests {
         for chunk in &data {
             writer.write_all(chunk).await?;
         }
+
+        // Object should not yet exist in store
+        let meta_res = storage.head(&location).await;
+        assert!(meta_res.is_err());
+        assert!(matches!(
+            meta_res.unwrap_err(),
+            crate::Error::NotFound { .. }
+        ));
+
         writer.shutdown().await?;
         let bytes_written = storage.get(&location).await?.bytes().await?;
         assert_eq!(bytes_expected, bytes_written);

--- a/src/local.rs
+++ b/src/local.rs
@@ -2,7 +2,7 @@
 use crate::{
     maybe_spawn_blocking,
     path::{filesystem_path_to_url, Path},
-    GetResult, ListResult, ObjectMeta, ObjectStore, Result, UploadId,
+    GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -231,10 +231,10 @@ impl ObjectStore for LocalFileSystem {
         .await
     }
 
-    async fn upload(
+    async fn put_multipart(
         &self,
         location: &Path,
-    ) -> Result<(UploadId, Box<dyn AsyncWrite + Unpin + Send>)> {
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
         let path = self.config.path_to_filesystem(location)?;
 
         let file = open_writable_file(&path)?;
@@ -248,7 +248,7 @@ impl ObjectStore for LocalFileSystem {
         ))
     }
 
-    async fn cleanup_upload(&self, location: &Path, _upload_id: &UploadId) -> Result<()> {
+    async fn cleanup_multipart(&self, location: &Path, _upload_id: &MultipartId) -> Result<()> {
         // Clean up partial write
         self.delete(location)
             .map(|res| match res {

--- a/src/local.rs
+++ b/src/local.rs
@@ -248,7 +248,7 @@ impl ObjectStore for LocalFileSystem {
         ))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, _upload_id: &MultipartId) -> Result<()> {
+    async fn cleanup_multipart(&self, location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // Clean up partial write
         self.delete(location)
             .map(|res| match res {

--- a/src/local.rs
+++ b/src/local.rs
@@ -248,7 +248,7 @@ impl ObjectStore for LocalFileSystem {
         ))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, _multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // Clean up partial write
         self.delete(location)
             .map(|res| match res {

--- a/src/local.rs
+++ b/src/local.rs
@@ -1028,14 +1028,14 @@ mod tests {
         let list = flatten_list_stream(&integration, None).await.unwrap();
         assert_eq!(list.len(), 0);
 
-        let list: Vec<Path> = integration
-            .list_with_delimiter(None)
-            .await
-            .unwrap()
-            .objects
-            .into_iter()
-            .map(|entry| entry.location)
-            .collect();
-        assert_eq!(list.len(), 0);
+        assert_eq!(
+            integration
+                .list_with_delimiter(None)
+                .await
+                .unwrap()
+                .objects
+                .len(),
+            0
+        );
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -86,7 +86,7 @@ impl ObjectStore for InMemory {
         ))
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // Nothing to clean up
         Ok(())
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -86,7 +86,7 @@ impl ObjectStore for InMemory {
         ))
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _upload_id: &MultipartId) -> Result<()> {
+    async fn cleanup_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         // Nothing to clean up
         Ok(())
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,5 @@
 //! An in-memory object store implementation
-use crate::UploadId;
+use crate::MultipartId;
 use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -72,10 +72,10 @@ impl ObjectStore for InMemory {
         Ok(())
     }
 
-    async fn upload(
+    async fn put_multipart(
         &self,
         location: &Path,
-    ) -> Result<(UploadId, Box<dyn AsyncWrite + Unpin + Send>)> {
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
         Ok((
             String::new(),
             Box::new(InMemoryUpload {
@@ -86,7 +86,7 @@ impl ObjectStore for InMemory {
         ))
     }
 
-    async fn cleanup_upload(&self, _location: &Path, _upload_id: &UploadId) -> Result<()> {
+    async fn cleanup_multipart(&self, _location: &Path, _upload_id: &MultipartId) -> Result<()> {
         // Nothing to clean up
         Ok(())
     }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,4 +1,4 @@
-use futures::{stream::FuturesUnordered, Future, StreamExt};
+use futures::{future::BoxFuture, stream::FuturesUnordered, Future, StreamExt};
 use std::{io, pin::Pin, sync::Arc, task::Poll};
 use tokio::io::AsyncWrite;
 
@@ -13,10 +13,13 @@ pub(crate) trait CloudMultiPartUploadImpl {
         &self,
         buf: Vec<u8>,
         part_idx: usize,
-    ) -> BoxedTryFuture<(usize, UploadPart)>;
+    ) -> BoxFuture<'static, Result<(usize, UploadPart), io::Error>>;
 
     /// Complete the upload with the provided parts
-    fn complete(&self, completed_parts: Vec<Option<UploadPart>>) -> BoxedTryFuture<()>;
+    fn complete(
+        &self,
+        completed_parts: Vec<Option<UploadPart>>,
+    ) -> BoxFuture<'static, Result<(), io::Error>>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,0 +1,189 @@
+use futures::StreamExt;
+use pin_project::pin_project;
+use std::{io, pin::Pin, sync::Arc, task::Poll};
+
+use async_trait::async_trait;
+use futures::{stream::FuturesUnordered, Future};
+use tokio::io::AsyncWrite;
+
+use crate::{MultiPartUpload, Result};
+
+type BoxedTryFuture<T> = Pin<Box<dyn Future<Output = Result<T, io::Error>> + Send>>;
+
+// Lifetimes are difficult to manage, so not using AsyncTrait
+pub(crate) trait CloudMultiPartUploadImpl {
+    /// Upload a single part
+    fn upload_part(&self, buf: Vec<u8>, part_idx: usize) -> BoxedTryFuture<(usize, UploadPart)>;
+
+    /// Complete the upload with the provided parts
+    fn complete(&self, completed_parts: Vec<Option<UploadPart>>) -> BoxedTryFuture<()>;
+
+    /// Cancel the upload in the cloud service
+    fn abort(&self) -> BoxedTryFuture<()>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UploadPart {
+    pub content_id: String,
+}
+
+#[pin_project]
+pub(crate) struct CloudMultiPartUpload<T>
+where
+    T: CloudMultiPartUploadImpl,
+{
+    inner: Arc<T>,
+    /// A list of completed parts, in sequential order.
+    completed_parts: Vec<Option<UploadPart>>,
+    #[pin]
+    /// Part upload tasks currently running
+    tasks: FuturesUnordered<BoxedTryFuture<(usize, UploadPart)>>,
+    /// Maximum number of upload tasks to run concurrently
+    max_concurrency: usize,
+    /// Buffer that will be sent in next upload.
+    current_buffer: Vec<u8>,
+    /// Minimum size of a part in bytes
+    min_part_size: usize,
+    /// Index of current part
+    current_part_idx: usize,
+    #[pin]
+    /// The completion task
+    completion_task: Option<BoxedTryFuture<()>>,
+}
+
+impl<T> CloudMultiPartUpload<T>
+where
+    T: CloudMultiPartUploadImpl,
+{
+    pub fn new(inner: T, max_concurrency: usize) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            completed_parts: Vec::new(),
+            tasks: FuturesUnordered::new(),
+            max_concurrency,
+            current_buffer: Vec::new(),
+            // TODO: Should this vary by provider?
+            // TODO: Should we automatically increase then when part index gets large?
+            min_part_size: 5_000_000,
+            current_part_idx: 0,
+            completion_task: None,
+        }
+    }
+
+    pub fn poll_tasks(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Result<(), io::Error> {
+        let mut this = self.project();
+        if this.tasks.is_empty() {
+            return Ok(());
+        }
+        while let Poll::Ready(Some(res)) = this.tasks.poll_next_unpin(cx) {
+            let (part_idx, part) = res?;
+            this.completed_parts.resize(
+                std::cmp::max(part_idx + 1, this.completed_parts.len()),
+                None,
+            );
+            this.completed_parts[part_idx] = Some(part);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<T> MultiPartUpload for CloudMultiPartUpload<T>
+where
+    T: CloudMultiPartUploadImpl + Send + Unpin + Sync,
+{
+    async fn abort(&mut self) -> Result<()> {
+        self.tasks.clear();
+        self.abort().await?;
+        Ok(())
+    }
+}
+
+impl<T> AsyncWrite for CloudMultiPartUpload<T>
+where
+    T: CloudMultiPartUploadImpl + Send + Sync,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        // Poll current tasks
+        self.as_mut().poll_tasks(cx)?;
+
+        let this = self.as_mut().project();
+
+        // If adding buf to pending buffer would trigger send, check
+        // whether we have capacity for another task.
+        let enough_to_send = (buf.len() + this.current_buffer.len()) > *this.min_part_size;
+        if enough_to_send && this.tasks.len() < *this.max_concurrency {
+            // If we do, copy into the buffer and submit the task, and return ready.
+            this.current_buffer.extend_from_slice(buf);
+
+            let out_buffer = std::mem::take(this.current_buffer);
+            let task = this.inner.upload_part(out_buffer, *this.current_part_idx);
+            this.tasks.push(task);
+            *this.current_part_idx += 1;
+
+            // We need to poll immediately after adding to setup waker
+            self.as_mut().poll_tasks(cx)?;
+
+            Poll::Ready(Ok(buf.len()))
+        } else if !enough_to_send {
+            this.current_buffer.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        } else {
+            // Waker registered by call to poll_tasks at beginning
+            Poll::Pending
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        // Poll current tasks
+        self.as_mut().poll_tasks(cx)?;
+
+        let this = self.as_mut().project();
+
+        // If current_buffer is not empty, see if it can be submitted
+        if !this.current_buffer.is_empty() && this.tasks.len() < *this.max_concurrency {
+            let out_buffer: Vec<u8> = std::mem::take(this.current_buffer);
+            let task = this.inner.upload_part(out_buffer, *this.current_part_idx);
+            this.tasks.push(task);
+        }
+
+        self.as_mut().poll_tasks(cx)?;
+
+        // If tasks and current_buffer are empty, return Ready
+        if self.tasks.is_empty() && self.current_buffer.is_empty() {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        // First, poll flush
+        match self.as_mut().poll_flush(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(res) => res?,
+        };
+
+        // If shutdown task is not set, set it
+        let parts = std::mem::take(&mut self.completed_parts);
+        let inner = Arc::clone(&self.inner);
+        let completion_task = self
+            .completion_task
+            .get_or_insert_with(|| inner.complete(parts));
+
+        Pin::new(completion_task).poll(cx)
+    }
+}

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -6,7 +6,11 @@ use crate::Result;
 
 type BoxedTryFuture<T> = Pin<Box<dyn Future<Output = Result<T, io::Error>> + Send>>;
 
-// Lifetimes are difficult to manage, so not using AsyncTrait
+/// A trait that can be implemented by cloud-based object stores
+/// and used in combination with [`CloudMultiPartUpload`] to provide
+/// multipart upload support
+///
+/// Note: this does not use AsyncTrait as the lifetimes are difficult to manage
 pub(crate) trait CloudMultiPartUploadImpl {
     /// Upload a single part
     fn put_multipart_part(
@@ -16,6 +20,8 @@ pub(crate) trait CloudMultiPartUploadImpl {
     ) -> BoxFuture<'static, Result<(usize, UploadPart), io::Error>>;
 
     /// Complete the upload with the provided parts
+    ///
+    /// `completed_parts` is in order of part number
     fn complete(
         &self,
         completed_parts: Vec<Option<UploadPart>>,

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -261,7 +261,7 @@ fn usize_to_u32_saturate(x: usize) -> u32 {
 
 enum ThrottledUploadState {
     Idle,
-    Sleeping(Pin<Box<dyn Future<Output = ()> + Send>>),
+    Sleeping(BoxFuture<'static, ()>),
     Waiting,
 }
 

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -141,7 +141,7 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         Err(super::Error::NotImplemented)
     }
 
-    async fn cleanup_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
+    async fn abort_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
         Err(super::Error::NotImplemented)
     }
 

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,4 +1,5 @@
 //! A throttling object store wrapper
+use futures::future::BoxFuture;
 use parking_lot::Mutex;
 use std::io;
 use std::ops::Range;

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::task::Poll;
 use std::{convert::TryInto, sync::Arc};
 
-use crate::UploadId;
+use crate::MultipartId;
 use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -138,11 +138,11 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         self.inner.put(location, bytes).await
     }
 
-    async fn upload(
+    async fn put_multipart(
         &self,
         location: &Path,
-    ) -> Result<(UploadId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        let (upload_id, inner) = self.inner.upload(location).await?;
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        let (upload_id, inner) = self.inner.put_multipart(location).await?;
         Ok((
             upload_id,
             Box::new(ThrottledUpload {
@@ -153,8 +153,8 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         ))
     }
 
-    async fn cleanup_upload(&self, location: &Path, upload_id: &UploadId) -> Result<()> {
-        self.inner.cleanup_upload(location, upload_id).await
+    async fn cleanup_multipart(&self, location: &Path, upload_id: &MultipartId) -> Result<()> {
+        self.inner.cleanup_multipart(location, upload_id).await
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -153,8 +153,8 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         ))
     }
 
-    async fn cleanup_multipart(&self, location: &Path, upload_id: &MultipartId) -> Result<()> {
-        self.inner.cleanup_multipart(location, upload_id).await
+    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+        self.inner.cleanup_multipart(location, multipart_id).await
     }
 
     async fn get(&self, location: &Path) -> Result<GetResult> {


### PR DESCRIPTION
Implements stream / multi-part upload for all object stores except GCP. Exposed as two new methods in `ObjectStore` trait:

```rust
   /// Get a multi-part upload that allows writing data in chunks
    async fn put_multipart(
        &self,
        location: &Path,
    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)>;

    /// Cleanup an aborted upload.
    async fn cleanup_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()>;
```

Follow-up work:
 * Need to expose concurrency options for cloud multi-part uploads and set tested default values.