### PR TITLE
feat: implement copy for azure and harmonize errors

### DIFF
--- a/src/azure.rs
+++ b/src/azure.rs
@@ -369,7 +369,7 @@ impl ObjectStore for MicrosoftAzure {
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
         let from_url = reqwest::Url::parse(&format!(
-            "{}{}/{}",
+            "{}/{}/{}",
             &self.blob_base_url, self.container_name, from
         ))
         .context(UnableToParseUrlSnafu {
@@ -447,7 +447,11 @@ pub fn new_azure(
     };
 
     let storage_client = storage_account_client.as_storage_client();
-    let blob_base_url = storage_account_client.blob_storage_url().to_string();
+    let blob_base_url = storage_account_client
+        .blob_storage_url()
+        .as_ref()
+        .trim_end_matches('/')
+        .to_string();
 
     let container_name = container_name.into();
 

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -326,15 +326,11 @@ impl ObjectStore for MicrosoftAzure {
                     .blobs
                     .into_iter()
                     .map(convert_object_meta)
-                    .filter(|it| {
-                        it.as_ref()
-                            .unwrap_or(&ObjectMeta {
-                                size: 0,
-                                location: "".into(),
-                                last_modified: chrono::offset::Utc::now(),
-                            })
-                            .size
-                            > 0
+                    .filter(|it| match it {
+                        // This is needed to filter out gen2 directories
+                        // https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-known-issues#blob-storage-apis
+                        Ok(meta) => meta.size > 0,
+                        Err(_) => true,
                     });
                 Some((Ok(futures::stream::iter(names)), next_state))
             }

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -188,17 +188,16 @@ impl ObjectStore for MicrosoftAzure {
             .execute()
             .await
             .map_err(|err| {
-                match err.downcast_ref::<azure_core::HttpError>() {
-                    Some(azure_core::HttpError::StatusCode { status, .. }) => {
-                        if status.as_u16() == 404 {
-                            return Error::NotFound {
-                                source: err,
-                                path: location.to_string(),
-                            };
-                        }
+                if let Some(azure_core::HttpError::StatusCode { status, .. }) =
+                    err.downcast_ref::<azure_core::HttpError>()
+                {
+                    if status.as_u16() == 404 {
+                        return Error::NotFound {
+                            source: err,
+                            path: location.to_string(),
+                        };
                     }
-                    _ => {}
-                }
+                };
                 Error::UnableToGetData {
                     source: err,
                     container: self.container_name.clone(),
@@ -220,17 +219,16 @@ impl ObjectStore for MicrosoftAzure {
             .execute()
             .await
             .map_err(|err| {
-                match err.downcast_ref::<azure_core::HttpError>() {
-                    Some(azure_core::HttpError::StatusCode { status, .. }) => {
-                        if status.as_u16() == 404 {
-                            return Error::NotFound {
-                                source: err,
-                                path: location.to_string(),
-                            };
-                        }
+                if let Some(azure_core::HttpError::StatusCode { status, .. }) =
+                    err.downcast_ref::<azure_core::HttpError>()
+                {
+                    if status.as_u16() == 404 {
+                        return Error::NotFound {
+                            source: err,
+                            path: location.to_string(),
+                        };
                     }
-                    _ => {}
-                }
+                };
                 Error::UnableToGetPieceOfData {
                     source: err,
                     container: self.container_name.clone(),

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -162,6 +162,7 @@ impl std::fmt::Display for MicrosoftAzure {
     }
 }
 
+#[allow(clippy::borrowed_box)]
 fn check_err_not_found(err: &Box<dyn std::error::Error + Send + Sync>) -> bool {
     if let Some(azure_core::HttpError::StatusCode { status, .. }) =
         err.downcast_ref::<azure_core::HttpError>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,22 +385,11 @@ mod tests {
         let content_list = flatten_list_stream(storage, None).await?;
         assert!(content_list.is_empty());
 
-        // Azure doesn't report semantic errors
-        let is_azure = store_str.starts_with("MicrosoftAzure");
-
         let err = storage.get(&location).await.unwrap_err();
-        assert!(
-            matches!(err, crate::Error::NotFound { .. }) || is_azure,
-            "{}",
-            err
-        );
+        assert!(matches!(err, crate::Error::NotFound { .. }), "{}", err);
 
         let err = storage.head(&location).await.unwrap_err();
-        assert!(
-            matches!(err, crate::Error::NotFound { .. }) || is_azure,
-            "{}",
-            err
-        );
+        assert!(matches!(err, crate::Error::NotFound { .. }), "{}", err);
 
         // Test handling of paths containing an encoded delimiter
 


### PR DESCRIPTION
This PR provides `copy` for the azure object store. I also restructured the errors to closer match how other errors are structured in the crate.

There are two things I am not totally sure about. 

1. Unit tests were failing for the list operation since it expected "directories" to be excluded. from the blob metadata the best indicaator I could find was the blob size, but not sure if that would be considered failsafe...
2. For copy we need the storage account url to construct a url for the source blob. I expected some clients to expose that url, but I could not find a public function that was helpful.

Once this gets merged, I would like to contribute a new azure adls gen2 store as well to get `copy_if_not_exists` :).