### PR TITLE
feat: use parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ snafu = "0.7"
 tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time"] }
 tracing = { version = "0.1" }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["rustls-tls"] }
+parking_lot = { version = "0.12" }
 # Filesystem integration
 url = "2.2"
 walkdir = "2"

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
 use futures::{stream::BoxStream, StreamExt};
+use parking_lot::RwLock;
 use snafu::{ensure, OptionExt, Snafu};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ops::Range;
-use tokio::sync::RwLock;
 
 /// A specialized `Error` for in-memory object store-related errors
 #[derive(Debug, Snafu)]
@@ -62,7 +62,7 @@ impl std::fmt::Display for InMemory {
 #[async_trait]
 impl ObjectStore for InMemory {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        self.storage.write().await.insert(location.clone(), bytes);
+        self.storage.write().insert(location.clone(), bytes);
         Ok(())
     }
 
@@ -93,14 +93,14 @@ impl ObjectStore for InMemory {
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        self.storage.write().await.remove(location);
+        self.storage.write().remove(location);
         Ok(())
     }
 
     async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
         let last_modified = Utc::now();
 
-        let storage = self.storage.read().await;
+        let storage = self.storage.read();
         let values: Vec<_> = storage
             .iter()
             .filter(move |(key, _)| prefix.map(|p| key.prefix_matches(p)).unwrap_or(true))
@@ -129,7 +129,7 @@ impl ObjectStore for InMemory {
         // Only objects in this base level should be returned in the
         // response. Otherwise, we just collect the common prefixes.
         let mut objects = vec![];
-        for (k, v) in self.storage.read().await.range((prefix)..) {
+        for (k, v) in self.storage.read().range((prefix)..) {
             let mut parts = match k.prefix_match(prefix) {
                 Some(parts) => parts,
                 None => break,
@@ -162,13 +162,13 @@ impl ObjectStore for InMemory {
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
         let data = self.get_bytes(from).await?;
-        self.storage.write().await.insert(to.clone(), data);
+        self.storage.write().insert(to.clone(), data);
         Ok(())
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
         let data = self.get_bytes(from).await?;
-        let mut storage = self.storage.write().await;
+        let mut storage = self.storage.write();
         if storage.contains_key(to) {
             return Err(Error::AlreadyExists {
                 path: to.to_string(),
@@ -188,7 +188,7 @@ impl InMemory {
 
     /// Creates a clone of the store
     pub async fn clone(&self) -> Self {
-        let storage = self.storage.read().await;
+        let storage = self.storage.read();
         let storage = storage.clone();
 
         Self {
@@ -197,7 +197,7 @@ impl InMemory {
     }
 
     async fn get_bytes(&self, location: &Path) -> Result<Bytes> {
-        let storage = self.storage.read().await;
+        let storage = self.storage.read();
         let bytes = storage
             .get(location)
             .cloned()

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,9 +1,7 @@
 //! A throttling object store wrapper
+use parking_lot::Mutex;
 use std::ops::Range;
-use std::{
-    convert::TryInto,
-    sync::{Arc, Mutex},
-};
+use std::{convert::TryInto, sync::Arc};
 
 use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
@@ -110,13 +108,13 @@ impl<T: ObjectStore> ThrottledStore<T> {
     where
         F: Fn(&mut ThrottleConfig),
     {
-        let mut guard = self.config.lock().expect("lock poissened");
+        let mut guard = self.config.lock();
         f(&mut guard)
     }
 
     /// Return copy of current config.
     pub fn config(&self) -> ThrottleConfig {
-        *self.config.lock().expect("lock poissened")
+        *self.config.lock()
     }
 }
 


### PR DESCRIPTION
I noticed whilst reviewing #20 that we were using an async lock for the InMemoryStore, for no obvious reason. No long-running or async operations take place under a lock, and so an async lock will just be slower, and more complicated, than a simple synchronous lock.

This PR also switches to parking_lot as it is faster, simpler and smaller than the standard library abstractions, and is pretty ubiquitous. 