### PR TITLE
feat: remove next_token from ListResult (#35)

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -227,6 +227,8 @@ impl ObjectStore for GoogleCloudStorage {
             prefix: format_prefix(prefix),
             ..Default::default()
         };
+
+        // Note: cloud_storage automatically handles pagination
         let object_lists = self
             .client
             .object()
@@ -258,6 +260,7 @@ impl ObjectStore for GoogleCloudStorage {
             ..Default::default()
         };
 
+        // Note: cloud_storage automatically handles pagination
         let mut object_lists = Box::pin(
             self.client
                 .object()
@@ -272,7 +275,6 @@ impl ObjectStore for GoogleCloudStorage {
             None => ListResult {
                 objects: vec![],
                 common_prefixes: vec![],
-                next_token: None,
             },
             Some(list_response) => {
                 let list_response = list_response.context(UnableToStreamListDataSnafu {
@@ -294,7 +296,6 @@ impl ObjectStore for GoogleCloudStorage {
                 ListResult {
                     objects,
                     common_prefixes,
-                    next_token: list_response.next_page_token,
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,6 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
 /// 1,000 objects based on the underlying object storage's limitations.
 #[derive(Debug)]
 pub struct ListResult {
-    /// Token passed to the API for the next page of list results.
-    pub next_token: Option<String>,
     /// Prefixes that are common (like directories)
     pub common_prefixes: Vec<Path>,
     /// Object metadata for the listing

--- a/src/local.rs
+++ b/src/local.rs
@@ -401,7 +401,6 @@ impl ObjectStore for LocalFileSystem {
             }
 
             Ok(ListResult {
-                next_token: None,
                 common_prefixes: common_prefixes.into_iter().collect(),
                 objects,
             })

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -156,7 +156,6 @@ impl ObjectStore for InMemory {
         Ok(ListResult {
             objects,
             common_prefixes: common_prefixes.into_iter().collect(),
-            next_token: None,
         })
     }
 


### PR DESCRIPTION
This dates from a previous incarnation of the API where pagination was exposed to the user, it can be removed

Closes #35 