### PR TITLE
fix: remove duplicated storage/v1 from gcp base url

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -98,7 +98,7 @@ struct ServiceAccountCredentials {
 }
 
 fn default_gcs_base_url() -> String {
-    "https://storage.googleapis.com/storage/v1".to_owned()
+    "https://storage.googleapis.com".to_owned()
 }
 
 fn default_disable_oauth() -> bool {


### PR DESCRIPTION
Regression introduced by #45.

This part of the base url was moved into individual requests:

https://github.com/influxdata/object_store_rs/blob/f8c88889de2de03ecb24c013ef1160526793d9a7/src/gcp.rs#L162