### PR TITLE
feat: Add support for WebIdentityProvider (EKS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
     docker:
       - image: quay.io/influxdb/rust:ci
-      - image: localstack/localstack
+      - image: localstack/localstack:0.14.4
       - image: mcr.microsoft.com/azure-storage/azurite
       - image: fsouza/fake-gcs-server
         command:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ percent-encoding = "2.1"
 rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }
 rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
+rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"]  }
 snafu = "0.7"
 tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time"] }
 tracing = { version = "0.1" }
@@ -53,7 +54,7 @@ walkdir = "2"
 azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest"]
 azure_test = ["azure", "azure_core/azurite_workaround", "azure_storage/azurite_workaround", "azure_storage_blobs/azurite_workaround"]
 gcp = ["serde", "serde_json", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64"]
-aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "hyper", "hyper-rustls"]
+aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "hyper", "hyper-rustls"]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"


### PR DESCRIPTION
We used to fallback to `InstanceMetadataProvider` if no explicit credentials are supplied.
This is very useful because it makes it easy to autoconfigure credentials when running workload on k8s.

AWS is moving away from InstanceMetadataProvider on K8s, and requires the `WebIdentityProvider` when running on `EKS`. 

This PR adds support for `WebIdentityProvider` in the same vein as it supported `InstanceMetadataProvider`, namely as a fallback when no other explicit auth methods is provided.