### PR TITLE
docs: remove code, and redirect to apache arrow site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rust Object Store
 
-A crate providing a generic interface to object stores, such as S3, Azure Blob Storage and Google Cloud Storage. Originally developed for [InfluxDB IOx](https://github.com/influxdata/influxdb_iox/) and later split out for external consumption.
+Warning: This repository is ARCHIVED.
 
-See [docs.rs](https://docs.rs/object_store) for usage instructions
+The Rust Object Store crate has moved to https://github.com/apache/arrow-rs/tree/master/object_store


### PR DESCRIPTION
Re https://github.com/influxdata/object_store_rs/issues/41 and https://github.com/apache/arrow-rs/issues/2030

# Rationale
We have donated object_store to the ASF and so we should remove this copy to make sure active development continues int he correct place

# Changes
Remove all code and update readme to point at new location